### PR TITLE
Start and stop a workflow from the panel that shows it

### DIFF
--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -154,6 +154,17 @@ impl DeploymentRecord {
     }
 }
 
+/// Where a team's deployment record and artifacts live.
+///
+/// One definition, because four places need this path and a copy that drifts
+/// would have `omar stop` and the daemon looking in different directories for
+/// the same run.
+pub fn dir_for(omar_dir: &Path, ea_id: crate::ea::EaId, team: &str) -> PathBuf {
+    crate::ea::ea_state_dir(ea_id, omar_dir)
+        .join("topologies")
+        .join(team)
+}
+
 pub fn record_path(dir: &Path) -> PathBuf {
     dir.join("deployment.json")
 }

--- a/src/omar.rs
+++ b/src/omar.rs
@@ -765,9 +765,7 @@ fn deployment_dir(omar_dir: &std::path::Path, ea_id: ea::EaId, team: &str) -> Re
     if !topology::valid_identifier(team) {
         anyhow::bail!("invalid team name '{team}'");
     }
-    Ok(ea::ea_state_dir(ea_id, omar_dir)
-        .join("topologies")
-        .join(team))
+    Ok(deploy::dir_for(omar_dir, ea_id, team))
 }
 
 /// Ask the runner to stop, then wait, bounded by the run's own invocation

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -215,6 +215,11 @@ pub struct Serve {
     agent_token: String,
     running: Arc<AtomicBool>,
     thread: Option<thread::JoinHandle<()>>,
+    /// The state the request handlers share. Kept only so a test can seed a
+    /// run the daemon believes is live, which is otherwise reachable only by
+    /// starting one for real.
+    #[cfg(test)]
+    context: Arc<Context_>,
 }
 
 impl Serve {
@@ -252,6 +257,8 @@ impl Serve {
         // every connection from a poll interval.
         let running = Arc::new(AtomicBool::new(true));
         let thread_running = running.clone();
+        #[cfg(test)]
+        let shared = context.clone();
         let thread = thread::spawn(move || {
             while thread_running.load(Ordering::Relaxed) {
                 match listener.accept() {
@@ -271,6 +278,8 @@ impl Serve {
             agent_token,
             running,
             thread: Some(thread),
+            #[cfg(test)]
+            context: shared,
         };
         // Before this returns, so that everything downstream of "the server
         // started" can rely on the context being there. It names this server,
@@ -583,6 +592,14 @@ fn handle_client(mut stream: TcpStream, context: Arc<Context_>) -> Result<()> {
                 .trim_start_matches("/v1/runs/")
                 .trim_end_matches("/panel");
             panel_status(&context, id)
+        }
+        // Before the run-record route, which would otherwise take the suffix
+        // for part of the id.
+        ("POST", rest) if rest.starts_with("/v1/runs/") && rest.ends_with("/stop") => {
+            let id = rest
+                .trim_start_matches("/v1/runs/")
+                .trim_end_matches("/stop");
+            stop_run(&context, id)
         }
         ("POST", rest) if rest.starts_with("/v1/runs/") && rest.ends_with("/panel") => {
             let id = rest
@@ -1428,6 +1445,46 @@ fn find_active_run<'a>(runs: &'a BTreeMap<String, RunRecord>, team: &str) -> Opt
         .find(|record| record.team == team && is_active(&record.status))
 }
 
+/// Ask a run to stop at its next tag boundary.
+///
+/// The same request `omar stop` makes: a control file the running loop reads
+/// between tags, so no invocation is cut mid-contract and teardown persists
+/// state, logs and outputs before the sessions go.
+///
+/// Graceful only. `omar kill` exists for a runner that has stopped answering,
+/// and that case cannot arise here — the runner is this daemon, so a request
+/// that reaches this function is served by the very process being asked to
+/// stop. A force path from the UI would be a harder action sitting one click
+/// from deploy, and it has nothing to fix that this does not.
+fn stop_run(context: &Arc<Context_>, id: &str) -> (u16, Value) {
+    let team = {
+        let runs = context.runs.lock().expect("serve runs poisoned");
+        match runs.get(id) {
+            Some(record) if is_active(&record.status) => record.team.clone(),
+            // Not an error worth alarming anyone with: asking a finished run to
+            // stop is a race with it finishing, and the outcome is the same.
+            Some(record) => {
+                return (
+                    200,
+                    json!({"run_id": id, "status": record.status, "stopping": false}),
+                )
+            }
+            None => return (404, json!({"error": "unknown run"})),
+        }
+    };
+
+    let dir = crate::deploy::dir_for(&context.omar_dir, context.ea_id, &team);
+    match crate::deploy::request_stop(&dir) {
+        // Accepted, not done: the run ends at the next tag boundary, and the
+        // record's status is what says when it has.
+        Ok(()) => (
+            202,
+            json!({"run_id": id, "status": "stopping", "stopping": true}),
+        ),
+        Err(error) => (500, json!({"error": format!("{error:#}")})),
+    }
+}
+
 fn is_active(status: &str) -> bool {
     status == "starting" || status == "running"
 }
@@ -1566,6 +1623,60 @@ mod tests {
             0,
         )
         .expect("server starts")
+    }
+
+    /// Stopping is a request the runner reads, not a kill.
+    ///
+    /// The route's whole job is to leave the same control file `omar stop`
+    /// leaves, in the directory the run is actually using — so the assertion
+    /// worth making is that the file lands where the runner looks.
+    #[test]
+    fn stopping_a_run_leaves_the_request_where_the_runner_reads_it() {
+        let server = test_server();
+        let address = server.address();
+
+        // A run the daemon believes is live, without agents to start.
+        let team = "Cadence";
+        {
+            let mut runs = server.context.runs.lock().expect("runs");
+            runs.insert(
+                "run-1".to_string(),
+                RunRecord {
+                    run_id: "run-1".to_string(),
+                    team: team.to_string(),
+                    status: "running".to_string(),
+                    diagram_address: None,
+                    started_at: 0,
+                    finished_at: None,
+                    error: None,
+                },
+            );
+        }
+
+        let dir = crate::deploy::dir_for(&server.context.omar_dir, 0, team);
+        std::fs::create_dir_all(&dir).expect("deployment dir");
+        assert!(!crate::deploy::stop_requested(&dir), "nothing asked yet");
+
+        let response = request(address, "POST", "/v1/runs/run-1/stop", Some("{}"));
+        assert!(response.contains(" 202 "), "{response}");
+        assert!(response.contains("\"stopping\":true"), "{response}");
+        assert!(
+            crate::deploy::stop_requested(&dir),
+            "the runner has nothing to read"
+        );
+
+        // A run that has already ended is not an error: asking is a race with
+        // it finishing, and the outcome is the same either way.
+        {
+            let mut runs = server.context.runs.lock().expect("runs");
+            runs.get_mut("run-1").expect("run").status = "completed".to_string();
+        }
+        let response = request(address, "POST", "/v1/runs/run-1/stop", Some("{}"));
+        assert!(response.contains(" 200 "), "{response}");
+        assert!(response.contains("\"stopping\":false"), "{response}");
+
+        let response = request(address, "POST", "/v1/runs/nobody/stop", Some("{}"));
+        assert!(response.contains(" 404 "), "{response}");
     }
 
     #[test]

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1467,37 +1467,47 @@ fn find_active_run<'a>(runs: &'a BTreeMap<String, RunRecord>, team: &str) -> Opt
 /// that reaches this function is served by the very process being asked to
 /// stop. A force path from the UI would be a harder action sitting one click
 /// from deploy, and it has nothing to fix that this does not.
+///
+/// Answers with the run record, like every other run route: 202 that the stop
+/// was accepted, 200 that the run had already ended -- a race with it
+/// finishing, and the outcome is the same either way.
 fn stop_run(context: &Arc<Context_>, id: &str) -> (u16, Value) {
     let team = {
         let runs = context.runs.lock().expect("serve runs poisoned");
         match runs.get(id) {
             Some(record) if is_active(&record.status) => record.team.clone(),
-            // Not an error worth alarming anyone with: asking a finished run to
-            // stop is a race with it finishing, and the outcome is the same.
-            Some(record) => {
-                return (
-                    200,
-                    json!({"run_id": id, "status": record.status, "stopping": false}),
-                )
-            }
+            Some(record) => return (200, json!(record)),
             None => return (404, json!({"error": "unknown run"})),
         }
     };
 
     let dir = crate::deploy::dir_for(&context.omar_dir, context.ea_id, &team);
-    match crate::deploy::request_stop(&dir) {
-        // Accepted, not done: the run ends at the next tag boundary, and the
-        // record's status is what says when it has.
-        Ok(()) => (
-            202,
-            json!({"run_id": id, "status": "stopping", "stopping": true}),
-        ),
-        Err(error) => (500, json!({"error": format!("{error:#}")})),
+    if let Err(error) = crate::deploy::request_stop(&dir) {
+        return (500, json!({"error": format!("{error:#}")}));
+    }
+
+    // Recorded, not just answered. The record is this API's account of the run
+    // -- `GET /v1/runs` would otherwise keep calling a stopping run `running`,
+    // to every client except the one that happened to ask. `RunEnd` overwrites
+    // it when the loop reaches the boundary.
+    let mut runs = context.runs.lock().expect("serve runs poisoned");
+    match runs.get_mut(id) {
+        // Re-checked because the run may have ended while the request was being
+        // written, and a finished status must not be walked back to stopping.
+        Some(record) if is_active(&record.status) => {
+            record.status = "stopping".to_string();
+            (202, json!(record))
+        }
+        Some(record) => (200, json!(record)),
+        None => (404, json!({"error": "unknown run"})),
     }
 }
 
+/// A stopping run is still active: it holds its tmux sessions until the current
+/// tag closes, so a second run of the same team would still be answered by the
+/// first one's panes.
 fn is_active(status: &str) -> bool {
-    status == "starting" || status == "running"
+    status == "starting" || status == "running" || status == "stopping"
 }
 
 fn now_unix() -> u64 {
@@ -1670,21 +1680,41 @@ mod tests {
 
         let response = request(address, "POST", "/v1/runs/run-1/stop", Some("{}"));
         assert!(response.contains(" 202 "), "{response}");
-        assert!(response.contains("\"stopping\":true"), "{response}");
         assert!(
             crate::deploy::stop_requested(&dir),
             "the runner has nothing to read"
         );
 
+        // Recorded, not merely answered. A client that reloads, and a second
+        // one that never saw the ask, both learn the run is stopping from here
+        // and from nowhere else.
+        assert!(response.contains("\"status\":\"stopping\""), "{response}");
+        assert_eq!(
+            server
+                .context
+                .runs
+                .lock()
+                .expect("runs")
+                .get("run-1")
+                .expect("run")
+                .status,
+            "stopping"
+        );
+
+        // And it stays active while it stops: the sessions are still up, so a
+        // second run of the team would be answered by the first one's panes.
+        assert!(is_active("stopping"));
+
         // A run that has already ended is not an error: asking is a race with
-        // it finishing, and the outcome is the same either way.
+        // it finishing, and the outcome is the same either way. The status it
+        // reached is not walked back to stopping.
         {
             let mut runs = server.context.runs.lock().expect("runs");
             runs.get_mut("run-1").expect("run").status = "completed".to_string();
         }
         let response = request(address, "POST", "/v1/runs/run-1/stop", Some("{}"));
         assert!(response.contains(" 200 "), "{response}");
-        assert!(response.contains("\"stopping\":false"), "{response}");
+        assert!(response.contains("\"status\":\"completed\""), "{response}");
 
         let response = request(address, "POST", "/v1/runs/nobody/stop", Some("{}"));
         assert!(response.contains(" 404 "), "{response}");

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -598,8 +598,19 @@ fn handle_client(mut stream: TcpStream, context: Arc<Context_>) -> Result<()> {
         ("POST", rest) if rest.starts_with("/v1/runs/") && rest.ends_with("/stop") => {
             let id = rest
                 .trim_start_matches("/v1/runs/")
-                .trim_end_matches("/stop");
-            stop_run(&context, id)
+                .trim_end_matches("/stop")
+                .to_string();
+            // Drained even though the route takes no arguments. Closing a
+            // socket with unread bytes still in it sends RST rather than FIN,
+            // and the client reads that as the connection being reset instead
+            // of as the answer -- which is what a `{}` body from a caller that
+            // sends one would have done.
+            if content_length > MAX_BODY_BYTES {
+                (413, json!({"error": "body too large"}))
+            } else {
+                let _ = read_body(content_length)?;
+                stop_run(&context, &id)
+            }
         }
         ("POST", rest) if rest.starts_with("/v1/runs/") && rest.ends_with("/panel") => {
             let id = rest
@@ -1677,6 +1688,14 @@ mod tests {
 
         let response = request(address, "POST", "/v1/runs/nobody/stop", Some("{}"));
         assert!(response.contains(" 404 "), "{response}");
+
+        // A body the route does not want is still a body it must read. Closing
+        // a socket with bytes left unread sends RST rather than FIN, and the
+        // client sees the connection reset instead of the answer. Large enough
+        // not to hide inside a buffer.
+        let ignored = format!("{{\"note\":\"{}\"}}", "x".repeat(16 * 1024));
+        let response = request(address, "POST", "/v1/runs/run-1/stop", Some(&ignored));
+        assert!(response.contains(" 200 "), "{response}");
     }
 
     #[test]

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -1415,9 +1415,7 @@ fn fail_deployment(
 
 pub fn run_topology(bytecode: &Bytecode, config: TopologyRunConfig<'_>) -> Result<RunEnd> {
     let state = verify(bytecode)?;
-    let runtime_dir = crate::ea::ea_state_dir(config.ea_id, config.omar_dir)
-        .join("topologies")
-        .join(&state.team);
+    let runtime_dir = deploy::dir_for(config.omar_dir, config.ea_id, &state.team);
     fs::create_dir_all(&runtime_dir)?;
     // One live run per team: its sessions are named by team and agent, so a
     // second run would be answered by the first run's panes.

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -416,6 +416,35 @@ button {
   min-height: 82px;
   border-bottom: 1px solid var(--line);
   padding: 18px 20px;
+  gap: 16px;
+}
+
+/* Starting and stopping the workflow, beside the workflow. Pushed to the far
+   end so the stats stay next to the name they describe. */
+.workflow-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.workflow-actions span[role="group"] {
+  display: flex;
+  gap: 6px;
+}
+
+.workflow-actions .primary-button,
+.workflow-actions .secondary-button {
+  height: 30px;
+  padding: 0 12px;
+  font-size: 11.5px;
+  white-space: nowrap;
+}
+
+/* Asked for and not yet arrived: a graceful stop lands at the next tag
+   boundary, so this holds until the run says it has ended. */
+.workflow-actions .secondary-button:disabled {
+  opacity: 0.6;
+  cursor: default;
 }
 
 h1,
@@ -649,6 +678,10 @@ h2 {
 
 .run-stats {
   gap: 24px;
+  /* The heading is `space-between`, which with a third child would strand the
+     stats in the middle. This keeps them against the controls on the right,
+     where they were when they were the only thing there. */
+  margin-left: auto;
 }
 
 .run-stats span {
@@ -1566,7 +1599,7 @@ h2 {
   color: #d8caff;
 }
 
-/* Deploy sits with send, since both act on what the operator just wrote. */
+/* What is left here acts on the message being written. */
 .composer-actions {
   display: flex;
   align-items: center;

--- a/web/app/lib/protocol.ts
+++ b/web/app/lib/protocol.ts
@@ -292,11 +292,30 @@ export function assertChatMessage(value: unknown): ChatMessage {
   return { ...message, design, progress, selection } as ChatMessage;
 }
 
+/**
+ * Every status `omar serve` can report, as one list the type and the runtime
+ * check are both built from.
+ *
+ * They used to be two hand-written copies, which is how `stopped` came to be a
+ * status the daemon sends and the client rejects: the union was updated and the
+ * check below was not. One list cannot disagree with itself.
+ */
+export const RUN_STATUSES = [
+  "starting",
+  "running",
+  "stopping",
+  "completed",
+  "stopped",
+  "failed",
+] as const;
+
+export type RunStatus = (typeof RUN_STATUSES)[number];
+
 /** A run as `omar serve` reports it. `diagram_address` is host:port, not a URL. */
 export type RunRecord = {
   run_id: string;
   team: string;
-  status: "starting" | "running" | "completed" | "failed";
+  status: RunStatus;
   diagram_address: string | null;
   started_at: number;
   finished_at: number | null;
@@ -308,8 +327,12 @@ export type RunRequest = {
   inputs: Record<string, unknown>;
 };
 
-export function isRunFinished(status: RunRecord["status"]): boolean {
-  return status === "completed" || status === "failed";
+/**
+ * Whether the run is over, however it ended. `stopped` is an ending like any
+ * other -- it is what a stop asked for, not a failure to be reported.
+ */
+export function isRunFinished(status: RunStatus): boolean {
+  return status === "completed" || status === "stopped" || status === "failed";
 }
 
 export function assertRunRecord(value: unknown): RunRecord {
@@ -320,12 +343,7 @@ export function assertRunRecord(value: unknown): RunRecord {
   if (typeof record.run_id !== "string" || typeof record.team !== "string") {
     throw new Error("Run response is missing required run fields.");
   }
-  if (
-    record.status !== "starting" &&
-    record.status !== "running" &&
-    record.status !== "completed" &&
-    record.status !== "failed"
-  ) {
+  if (!RUN_STATUSES.includes(record.status as RunStatus)) {
     throw new Error(`Unsupported run status ${String(record.status)}.`);
   }
   return record as RunRecord;

--- a/web/app/lib/runtime-client.ts
+++ b/web/app/lib/runtime-client.ts
@@ -290,6 +290,32 @@ export async function answerPanel(
   if (!response.ok) throw new Error(await readError(response));
 }
 
+/**
+ * Ask a run to stop at its next tag boundary.
+ *
+ * Accepted, not done. A graceful stop closes the current tag before it
+ * persists and tears down, so the answer says it was heard and the run
+ * record is what says when it has finished. `stopping: false` means the run
+ * had already ended — a race with it finishing, not a failure.
+ */
+export async function stopRun(
+  serveUrl: string,
+  runId: string,
+  signal?: AbortSignal,
+): Promise<{ stopping: boolean; status: string }> {
+  const base = normalizeRuntimeUrl(serveUrl);
+  const response = await fetch(
+    `${base}/v1/runs/${encodeURIComponent(runId)}/stop`,
+    { method: "POST", headers: { "content-type": "application/json" }, body: "{}", signal },
+  );
+  if (!response.ok) throw new Error(await readError(response));
+  const body = (await response.json()) as { stopping?: unknown; status?: unknown };
+  return {
+    stopping: body.stopping === true,
+    status: typeof body.status === "string" ? body.status : "unknown",
+  };
+}
+
 export async function fetchRun(
   serveUrl: string,
   runId: string,

--- a/web/app/lib/runtime-client.ts
+++ b/web/app/lib/runtime-client.ts
@@ -293,27 +293,23 @@ export async function answerPanel(
 /**
  * Ask a run to stop at its next tag boundary.
  *
- * Accepted, not done. A graceful stop closes the current tag before it
- * persists and tears down, so the answer says it was heard and the run
- * record is what says when it has finished. `stopping: false` means the run
- * had already ended — a race with it finishing, not a failure.
+ * Accepted, not done: a graceful stop closes the current tag before it
+ * persists and tears down. Answers with the run record, so the caller learns
+ * the run is `stopping` from the same field it already watches — and a record
+ * that comes back already finished is a race with it ending, not a failure.
  */
 export async function stopRun(
   serveUrl: string,
   runId: string,
   signal?: AbortSignal,
-): Promise<{ stopping: boolean; status: string }> {
+): Promise<RunRecord> {
   const base = normalizeRuntimeUrl(serveUrl);
   const response = await fetch(
     `${base}/v1/runs/${encodeURIComponent(runId)}/stop`,
     { method: "POST", headers: { "content-type": "application/json" }, body: "{}", signal },
   );
   if (!response.ok) throw new Error(await readError(response));
-  const body = (await response.json()) as { stopping?: unknown; status?: unknown };
-  return {
-    stopping: body.stopping === true,
-    status: typeof body.status === "string" ? body.status : "unknown",
-  };
+  return assertRunRecord(await response.json());
 }
 
 export async function fetchRun(

--- a/web/app/studio.tsx
+++ b/web/app/studio.tsx
@@ -126,8 +126,6 @@ export function Studio({
   });
   // Deploying starts real agents, so the button arms a second, explicit step.
   const [confirming, setConfirming] = useState(false);
-  /** A stop has been asked for and the run has not ended yet. */
-  const [stopping, setStopping] = useState(false);
   const [daemon, setDaemon] = useState<Daemon>(
     isDemo ? { state: "demo" } : { state: "checking" },
   );
@@ -369,7 +367,9 @@ export function Studio({
           if (latest) {
             setRun(latest);
             if (isRunFinished(latest.status)) {
-              setPhase(latest.status === "completed" ? "finished" : "failed");
+              // `stopped` is the ending a stop asked for, so it reads as
+              // finished; only `failed` is a failure.
+              setPhase(latest.status === "failed" ? "failed" : "finished");
               if (latest.error) setError(latest.error);
               return;
             }
@@ -436,8 +436,6 @@ export function Studio({
   async function confirmDesign() {
     if (!design || phase !== "review") return;
     setConfirming(false);
-    // A new run is not stopping, whatever the last one was doing.
-    setStopping(false);
     setPhase("spawning");
     setError("");
     try {
@@ -465,19 +463,19 @@ export function Studio({
    * A graceful stop lands at the next tag boundary rather than immediately, so
    * the button has to hold a *stopping* state — one that just went quiet would
    * read as hung for however long the current invocation takes.
+   *
+   * That state belongs to the run, not to this component. The daemon records it
+   * and answers with the record, so the button reads the same field it already
+   * watches for every other status — one source, which cannot disagree with
+   * itself the way a remembered click and a polled record can.
    */
   async function requestStop() {
-    if (!run || stopping) return;
-    setStopping(true);
+    if (!run || isStopping) return;
     setError("");
     try {
-      const outcome = await stopRun(serveUrl, run.run_id);
-      // Already over: a race with it finishing, not a failure. The run record
-      // is about to say so, and nothing is still stopping.
-      if (!outcome.stopping) setStopping(false);
+      setRun(await stopRun(serveUrl, run.run_id));
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause));
-      setStopping(false);
     }
   }
 
@@ -578,9 +576,9 @@ export function Studio({
   }, [source, filename, serveUrl, canRun, presentKey]);
 
   const isDeployed = run !== null;
-  // Only meaningful while a run is in flight: however it ended, nothing is
-  // still stopping, and a button left saying so would outlive its subject.
-  const isStopping = stopping && phase === "observing";
+  // The daemon's own word for it. Every terminal status replaces it, so the
+  // state cannot outlive the run it was asked of.
+  const isStopping = run?.status === "stopping";
 
   // Widths are clamped against the workspace so the diagram always keeps a
   // usable column, whichever divider is being dragged. Below a panel's minimum

--- a/web/app/studio.tsx
+++ b/web/app/studio.tsx
@@ -39,6 +39,7 @@ import {
   fetchRun,
   checkProgram,
   startRun,
+  stopRun,
   subscribeToDiagram,
 } from "./lib/runtime-client";
 
@@ -125,6 +126,8 @@ export function Studio({
   });
   // Deploying starts real agents, so the button arms a second, explicit step.
   const [confirming, setConfirming] = useState(false);
+  /** A stop has been asked for and the run has not ended yet. */
+  const [stopping, setStopping] = useState(false);
   const [daemon, setDaemon] = useState<Daemon>(
     isDemo ? { state: "demo" } : { state: "checking" },
   );
@@ -433,6 +436,8 @@ export function Studio({
   async function confirmDesign() {
     if (!design || phase !== "review") return;
     setConfirming(false);
+    // A new run is not stopping, whatever the last one was doing.
+    setStopping(false);
     setPhase("spawning");
     setError("");
     try {
@@ -451,6 +456,28 @@ export function Studio({
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause));
       setPhase("review");
+    }
+  }
+
+  /**
+   * Ask the run to stop, and keep saying so until it has.
+   *
+   * A graceful stop lands at the next tag boundary rather than immediately, so
+   * the button has to hold a *stopping* state — one that just went quiet would
+   * read as hung for however long the current invocation takes.
+   */
+  async function requestStop() {
+    if (!run || stopping) return;
+    setStopping(true);
+    setError("");
+    try {
+      const outcome = await stopRun(serveUrl, run.run_id);
+      // Already over: a race with it finishing, not a failure. The run record
+      // is about to say so, and nothing is still stopping.
+      if (!outcome.stopping) setStopping(false);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+      setStopping(false);
     }
   }
 
@@ -551,6 +578,9 @@ export function Studio({
   }, [source, filename, serveUrl, canRun, presentKey]);
 
   const isDeployed = run !== null;
+  // Only meaningful while a run is in flight: however it ended, nothing is
+  // still stopping, and a button left saying so would outlive its subject.
+  const isStopping = stopping && phase === "observing";
 
   // Widths are clamped against the workspace so the diagram always keeps a
   // usable column, whichever divider is being dragged. Below a panel's minimum
@@ -699,16 +729,16 @@ export function Studio({
               aria-label="Describe a workflow"
             />
             <div>
-              {phase === "observing" || (phase === "review" && !canRun) ? (
-                // A run to report on, or a reason deploying is unavailable.
-                // Holding a design is neither: the deploy button already says
-                // it has not run, so the corner keeps naming the assistant.
+              {phase === "review" && !canRun ? (
+                // Why deploying is unavailable, which is about this composer's
+                // reach rather than about the workflow. The run's own state
+                // left with the buttons: the panel says STATUS beside the
+                // control that changes it, and saying it twice invited the two
+                // to disagree.
                 <span className="composer-status">
-                  {phase === "observing"
-                    ? "Run in progress"
-                    : daemon.state === "demo"
-                      ? "Demo topology — relaunch with OMAR_SERVE_URL to deploy"
-                      : `Cannot reach omar serve at ${serveUrl}`}
+                  {daemon.state === "demo"
+                    ? "Demo topology — relaunch with OMAR_SERVE_URL to deploy"
+                    : `Cannot reach omar serve at ${serveUrl}`}
                 </span>
               ) : (
                 <BackendMenu
@@ -716,49 +746,10 @@ export function Studio({
                   live={daemon.state === "live"}
                 />
               )}
+              {/* Deploying and stopping live on the workflow panel, beside the
+                  topology they act on. What is left here acts on the message
+                  being written. */}
               <div className="composer-actions">
-                {phase === "review" && design ? (
-                  <span role="group" aria-label="Deploy design">
-                    {confirming ? (
-                      <>
-                        <button
-                          className="secondary-button"
-                          onClick={() => setConfirming(false)}
-                          type="button"
-                        >
-                          Cancel
-                        </button>
-                        <button
-                          className="primary-button"
-                          onClick={() => void confirmDesign()}
-                          type="button"
-                          disabled={!canRun}
-                          title="This starts real agents"
-                        >
-                          Confirm deploy
-                        </button>
-                      </>
-                    ) : (
-                      <>
-                        <button
-                          className="secondary-button"
-                          onClick={discardDesign}
-                          type="button"
-                        >
-                          Discard
-                        </button>
-                        <button
-                          className="primary-button"
-                          onClick={() => setConfirming(true)}
-                          type="button"
-                          disabled={!canRun}
-                        >
-                          Deploy
-                        </button>
-                      </>
-                    )}
-                  </span>
-                ) : null}
                 <button
                   className="send-button"
                   type="submit"
@@ -790,7 +781,11 @@ export function Studio({
         <section className="diagram-panel">
           <div className="diagram-heading">
             <div>
-              <span className="eyebrow">LIVE TOPOLOGY</span>
+              {/* The panel draws a proposal before a run and the run after it,
+                  so it has to say which one is on screen. */}
+              <span className="eyebrow">
+                {snapshot.status === "ready" ? "PROPOSED TOPOLOGY" : "LIVE TOPOLOGY"}
+              </span>
               <h2>{snapshot?.team}</h2>
             </div>
             <div className="run-stats">
@@ -798,6 +793,67 @@ export function Studio({
               <span><small>TAG</small>{tag}</span>
               <span><small>LAG</small>{lag}</span>
             </div>
+            {(phase === "review" && design) || (phase === "observing" && run) ? (
+            <div className="workflow-actions">
+              {phase === "review" && design ? (
+                <span role="group" aria-label="Deploy design">
+                  {confirming ? (
+                    <>
+                      <button
+                        className="secondary-button"
+                        onClick={() => setConfirming(false)}
+                        type="button"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        className="primary-button"
+                        onClick={() => void confirmDesign()}
+                        type="button"
+                        disabled={!canRun}
+                        title="This starts real agents"
+                      >
+                        Confirm deploy
+                      </button>
+                    </>
+                  ) : (
+                    <>
+                      <button
+                        className="secondary-button"
+                        onClick={discardDesign}
+                        type="button"
+                      >
+                        Discard
+                      </button>
+                      <button
+                        className="primary-button"
+                        onClick={() => setConfirming(true)}
+                        type="button"
+                        disabled={!canRun}
+                      >
+                        Deploy
+                      </button>
+                    </>
+                  )}
+                </span>
+              ) : null}
+              {phase === "observing" && run ? (
+                <button
+                  className="secondary-button"
+                  onClick={() => void requestStop()}
+                  type="button"
+                  disabled={isStopping}
+                  title={
+                    isStopping
+                      ? "The current tag has to close first"
+                      : "Closes the current tag, then persists and tears down"
+                  }
+                >
+                  {isStopping ? "Stopping…" : "Stop"}
+                </button>
+              ) : null}
+            </div>
+            ) : null}
           </div>
           <DiagramCanvas
             snapshot={snapshot}

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,7 @@
     "build": "WRANGLER_LOG_PATH=.wrangler/wrangler.log vinext build",
     "build:spa": "vite build --config vite.spa.config.ts && node build/compress-spa.mjs",
     "start": "WRANGLER_LOG_PATH=.wrangler/wrangler.log vinext start",
-    "test": "npm run build && node --test tests/rendered-html.test.mjs tests/protocol-contract.test.mjs",
+    "test": "npm run build && node --test --experimental-strip-types --disable-warning=ExperimentalWarning tests/rendered-html.test.mjs tests/protocol-contract.test.mjs",
     "lint": "eslint . --ignore-pattern dist --ignore-pattern .next",
     "test:e2e": "playwright test",
     "test:conformance": "node --test tests/conformance.test.mjs",

--- a/web/tests/e2e/flow.spec.ts
+++ b/web/tests/e2e/flow.spec.ts
@@ -656,16 +656,23 @@ test("the studio opens on a centred prompt, then settles into a thread", async (
   expect(Math.abs(messageCentre - viewport.width / 2)).toBeLessThan(40);
 });
 
-test("the composer's buttons line up", async ({ page }) => {
+test("the workflow's buttons sit with the workflow", async ({ page }) => {
   await useFakeServe(page);
   await draftUntilProposed(page);
 
-  // Discard, Deploy and send sit in a row; differing heights read as sloppy.
+  // Deploying acts on the topology, not on the message being written, so the
+  // controls belong to the panel drawing it.
+  const actions = page.locator(".diagram-heading .workflow-actions");
+  await expect(actions.getByRole("button", { name: "Discard" })).toBeVisible();
+  await expect(actions.getByRole("button", { name: "Deploy", exact: true })).toBeVisible();
+  await expect(page.locator(".composer-actions").getByRole("button", { name: "Deploy" }))
+    .toHaveCount(0);
+
+  // Discard and Deploy sit in a row; differing heights read as sloppy.
   const boxes = await Promise.all(
     [
-      page.getByRole("button", { name: "Discard" }),
-      page.getByRole("button", { name: "Deploy", exact: true }),
-      page.getByLabel("Draft workflow"),
+      actions.getByRole("button", { name: "Discard" }),
+      actions.getByRole("button", { name: "Deploy", exact: true }),
     ].map(async (button) => (await button.boundingBox())!),
   );
   const [first] = boxes;
@@ -673,6 +680,42 @@ test("the composer's buttons line up", async ({ page }) => {
     expect(Math.round(box.height)).toBe(Math.round(first.height));
     expect(Math.round(box.y)).toBe(Math.round(first.y));
   }
+
+  // And the stats did not get stranded in the middle by the third child.
+  const stats = (await page.locator(".run-stats").boundingBox())!;
+  expect(stats.x).toBeGreaterThan(
+    (await page.locator(".diagram-heading h2").boundingBox())!.x,
+  );
+  expect(stats.x + stats.width).toBeLessThanOrEqual(first.x + 1);
+});
+
+test("a run can be stopped from the panel that shows it", async ({ page }) => {
+  // Until now the only way to end a run started from the UI was to leave the
+  // UI and type `omar stop` in a terminal.
+  await useFakeServe(page);
+  await draftUntilProposed(page);
+
+  // The eyebrow says which topology is on screen: this one has not run.
+  await expect(page.locator(".diagram-heading .eyebrow")).toHaveText("PROPOSED TOPOLOGY");
+  const actions = page.locator(".diagram-heading .workflow-actions");
+  await expect(actions.getByRole("button", { name: "Stop" })).toHaveCount(0);
+
+  await deploy(page);
+  await expect(page.locator(".diagram-heading .eyebrow")).toHaveText("LIVE TOPOLOGY");
+
+  const stop = actions.getByRole("button", { name: "Stop" });
+  await expect(stop).toBeEnabled();
+  await stop.click();
+
+  // A graceful stop lands at the next tag boundary, so the button has to say
+  // it was heard. One that just went quiet would read as hung.
+  await expect(actions.getByRole("button", { name: "Stopping…" })).toBeDisabled();
+
+  // And when the run ends the control goes with it -- there is nothing left to
+  // stop, and a button still offering to would be lying.
+  await expect(actions.getByRole("button", { name: /Stop/ })).toHaveCount(0, {
+    timeout: 5000,
+  });
 });
 
 test("discarding puts the topology away too", async ({ page }) => {

--- a/web/tests/e2e/flow.spec.ts
+++ b/web/tests/e2e/flow.spec.ts
@@ -716,6 +716,14 @@ test("a run can be stopped from the panel that shows it", async ({ page }) => {
   await expect(actions.getByRole("button", { name: /Stop/ })).toHaveCount(0, {
     timeout: 5000,
   });
+
+  // A stop is the ending it asked for, not a failure. The run settles to
+  // `stopped`, which the client has to both accept as a status and read as an
+  // ordinary end -- it did neither, and the run came to rest looking broken.
+  await expect(page.locator(".connection")).toContainText("finished", {
+    timeout: 5000,
+  });
+  await expect(page.locator(".connection-error")).toHaveCount(0);
 });
 
 test("discarding puts the topology away too", async ({ page }) => {

--- a/web/tests/fake-serve.mjs
+++ b/web/tests/fake-serve.mjs
@@ -72,6 +72,35 @@ export async function startFakeServe({
     }
     // Before the run-record route, which matches any suffix — the same order
     // the daemon's own arms are in, and for the same reason.
+    // Before the run-record route, as on the daemon, which would otherwise
+    // take the suffix for part of the id.
+    if (
+      request.method === "POST" &&
+      url.pathname.startsWith("/v1/runs/") &&
+      url.pathname.endsWith("/stop")
+    ) {
+      const id = url.pathname.slice("/v1/runs/".length, -"/stop".length);
+      const entry = runs.get(id);
+      if (!entry) return json(response, 404, { error: "unknown run" });
+      const active = entry.record.status === "running" || entry.record.status === "starting";
+      if (!active) {
+        return json(response, 200, {
+          run_id: id,
+          status: entry.record.status,
+          stopping: false,
+        });
+      }
+      // Accepted, not done: the daemon answers before the run has ended, and
+      // the record is what says when it has. Held briefly so the client's
+      // waiting state is a state a test can see.
+      entry.stopping = true;
+      setTimeout(() => {
+        entry.record.status = "stopped";
+        entry.record.finished_at = Math.floor(Date.now() / 1000);
+        publish(entry, "run_completed", { status: "stopped" });
+      }, 400);
+      return json(response, 202, { run_id: id, status: "stopping", stopping: true });
+    }
     if (url.pathname.startsWith("/v1/runs/") && url.pathname.endsWith("/panel")) {
       const id = url.pathname.slice("/v1/runs/".length, -"/panel".length);
       const entry = runs.get(id);

--- a/web/tests/fake-serve.mjs
+++ b/web/tests/fake-serve.mjs
@@ -72,8 +72,6 @@ export async function startFakeServe({
     }
     // Before the run-record route, which matches any suffix — the same order
     // the daemon's own arms are in, and for the same reason.
-    // Before the run-record route, as on the daemon, which would otherwise
-    // take the suffix for part of the id.
     if (
       request.method === "POST" &&
       url.pathname.startsWith("/v1/runs/") &&
@@ -82,24 +80,20 @@ export async function startFakeServe({
       const id = url.pathname.slice("/v1/runs/".length, -"/stop".length);
       const entry = runs.get(id);
       if (!entry) return json(response, 404, { error: "unknown run" });
-      const active = entry.record.status === "running" || entry.record.status === "starting";
-      if (!active) {
-        return json(response, 200, {
-          run_id: id,
-          status: entry.record.status,
-          stopping: false,
-        });
-      }
+      // A stopping run is still active, as on the daemon: it holds its sessions
+      // until the tag closes.
+      const active = ["starting", "running", "stopping"].includes(entry.record.status);
+      if (!active) return json(response, 200, entry.record);
       // Accepted, not done: the daemon answers before the run has ended, and
-      // the record is what says when it has. Held briefly so the client's
-      // waiting state is a state a test can see.
-      entry.stopping = true;
+      // records `stopping` so a client that reloads still sees it. Held briefly
+      // so that waiting state is one a test can observe.
+      entry.record.status = "stopping";
       setTimeout(() => {
         entry.record.status = "stopped";
         entry.record.finished_at = Math.floor(Date.now() / 1000);
         publish(entry, "run_completed", { status: "stopped" });
       }, 400);
-      return json(response, 202, { run_id: id, status: "stopping", stopping: true });
+      return json(response, 202, entry.record);
     }
     if (url.pathname.startsWith("/v1/runs/") && url.pathname.endsWith("/panel")) {
       const id = url.pathname.slice("/v1/runs/".length, -"/panel".length);

--- a/web/tests/protocol-contract.test.mjs
+++ b/web/tests/protocol-contract.test.mjs
@@ -14,6 +14,7 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 import { startFakeServe, INVALID_MARKER } from "./fake-serve.mjs";
+import { RUN_STATUSES, assertRunRecord, isRunFinished } from "../app/lib/protocol.ts";
 
 const golden = JSON.parse(
   await readFile(new URL("./fixtures/diagram-snapshot.v1.json", import.meta.url), "utf8"),
@@ -90,6 +91,38 @@ test("the demo fixture is the captured topology, not an invented one", async () 
     assert.ok(fixtures.includes(`id: "${port.id}"`), `fixture carries ${port.id}`);
   }
   assert.match(fixtures, /export const reviewProgram = `team ReviewFlow\[/);
+});
+
+test("the client accepts every run status the daemon can send", async () => {
+  // Read out of the daemon's source rather than out of a built binary: this has
+  // to fail in seconds in a checkout with no Rust toolchain, because `web.yml`'s
+  // test job has none. Same bargain as the fixture check above.
+  const serve = await readFile(new URL("../../src/serve.rs", import.meta.url), "utf8");
+  const emitted = [...serve.matchAll(/\bstatus:? =? ?"([a-z]+)"/g)].map((m) => m[1]);
+  assert.deepEqual(
+    [...new Set(emitted)].sort(),
+    [...RUN_STATUSES].sort(),
+    "the daemon and the client disagree about what a run status is",
+  );
+
+  // Naming the status is not enough. `stopped` reached the union while the
+  // parser kept its own hand-written list, so a stopped run arrived as an
+  // unreadable one and the page sat on a run that had already ended.
+  const record = {
+    run_id: "run-1",
+    team: "Cadence",
+    diagram_address: null,
+    started_at: 0,
+    finished_at: null,
+    error: null,
+  };
+  for (const status of RUN_STATUSES) {
+    assert.equal(assertRunRecord({ ...record, status }).status, status);
+  }
+
+  // A stop is an ending; asking for one is not.
+  assert.ok(isRunFinished("stopped"), "a stopped run has ended");
+  assert.ok(!isRunFinished("stopping"), "a stopping run has not ended yet");
 });
 
 test("run admission accepts a program and reports where to observe it", async () => {


### PR DESCRIPTION
Closes #235.

The controls that start a program lived in the chat composer beside the send arrow — attached to the box you type prompts into rather than to the workflow they act on. Nothing stopped a program at all: once deployed from the UI, the only way to end it was to leave the UI and run `omar stop` in a terminal.

Both now sit on the workflow panel heading, beside the `STATUS` / `TAG` / `LAG` it already reports. The two-step confirm stays — deploying starts real agents.

## The route

`POST /v1/runs/{id}/stop` leaves the same control file `omar stop` leaves, in the same directory, so the running loop reads it between tags. No invocation is cut mid-contract, and teardown persists state, logs and outputs before the sessions go. The mechanism is #226's; this is the route, the client call and the buttons.

A run that has already ended answers `200 {"stopping": false}` rather than an error — asking is a race with it finishing, and the outcome is the same.

## Graceful only, deliberately

#235 asked whether to expose force as well. No, and the reason is architectural rather than a matter of taste: `omar kill` exists for a runner that has stopped answering, and **that cannot arise here**. The runner is this daemon, so a request that arrives at all is served by the very process being asked to stop. A force path would be a harder action sitting one click from deploy, with nothing to fix that graceful stop does not.

That also answers *"handle the runner dying mid-stop"* — the CLI's dead-runner escalation is about a separate `omar run` process, not about a run the daemon is hosting.

## Stopping is a state, not a moment

A graceful stop lands at the next tag boundary, so the button holds a **Stopping…** state; one that just went quiet would read as hung.

That state is the run's, so the daemon records it. `stop_run` writes `stopping` onto the record and answers with the record, like every other run route. The first version of this branch kept it in a `useState` and argued that deriving it was the safer choice — it is not: nothing else could see it. `GET /v1/runs` went on calling a stopping run `running` to every client except the one that happened to ask. The button now reads the field it already watches for every other status, and the local state is gone.

`is_active` counts `stopping` as active, because it is: the run holds its tmux sessions until the tag closes, so a second run of the team would still be answered by the first one's panes.

## The status a run ends on

Same fault, other end — and this half is not this branch's doing. `main` already answers `stopped` (`RunEnd::Stopped`, `serve.rs:1394`), and `main`'s client has it in neither the union nor `assertRunRecord`, so a stopped run has always parsed as an unreadable one. What this branch changes is that it became reachable: before the button, a run only stopped if someone left the UI and typed `omar stop`.

The SSE `run_completed` hid it. The fallback could not: the diagram server dies with the run, so a dropped stream is the *expected* ending and `settle` is what recovers from it — and `settle` could neither parse the record nor, via `isRunFinished`, recognise `stopped` as an ending. The page would have sat on a disabled **Stopping…** for a run that finished minutes earlier, which is the failure the button exists to prevent. `settle` also read every non-`completed` ending as a failure, so a deliberate stop reported as one.

One list now backs both the type and the runtime check:

```ts
export const RUN_STATUSES = ["starting", "running", "stopping", "completed", "stopped", "failed"] as const;
export type RunStatus = (typeof RUN_STATUSES)[number];
```

Two hand-written copies is how this happened, and one list cannot disagree with itself.

## Three decisions #235 left open

**The eyebrow.** It said `LIVE TOPOLOGY` over a proposal that had never run. It now keys on the snapshot's own status — a preview is `"ready"`, so it says `PROPOSED TOPOLOGY`.

My first attempt keyed it on the run record, which looked right and was wrong: the demo topology has no record and is still live. The server-render test caught it, which is a good argument for that test existing.

**The composer corner.** No longer reports the run. The panel says `STATUS` beside the control that changes it, and saying it twice invited the two to disagree. What is left there — why deploying is unavailable — is about the composer's own reach.

**Layout.** `.diagram-heading` is `space-between`, so a third child would have stranded the stats in the middle. They keep to the right, where they were, and the test asserts it.

## Also

`deploy::dir_for` — four places needed the deployment directory and three had hand-rolled it. A fourth copy would have been the mess; one definition means `omar stop` and the daemon cannot end up looking in different directories for the same run.

## Tests

- `stopping_a_run_leaves_the_request_where_the_runner_reads_it` — asserts the control file lands where the runner looks, that the record is left saying `stopping`, that a finished run is not an error and is not walked back, and that an unknown one is a 404. Needed a test-scoped handle on the daemon's context, since a run is otherwise only reachable by starting one for real.
- `the client accepts every run status the daemon can send` — pins `RUN_STATUSES` to the statuses `serve.rs` actually emits, read out of the source rather than a built binary, because `web.yml`'s test job has no Rust toolchain. Reverting the list fails it with *the daemon and the client disagree about what a run status is*. It also asserts the parser accepts each one, since naming the status and accepting it were separately wrong.
- `a run can be stopped from the panel that shows it` — no Stop before deploy, the eyebrow flips, Stop → `Stopping…` disabled → gone when the run ends, and the run comes to rest **finished** with no error banner rather than looking broken.
- `the workflow's buttons sit with the workflow` — replaces the old composer-alignment test, and checks the stats did not get stranded.

389 Rust, 48 browser, 13 web unit; fmt, clippy and eslint clean. Three Rust failures on this machine (`config::test_detect_agent_command_*`, `backend_probe::command_timeout_reports_successful_probe`, `scheduler::event_loop_keeps_deferring_while_popup_stays_open`) reproduce on a clean checkout of the base commit and are unrelated to this branch.

The web unit suite now runs with `--experimental-strip-types` so a test can import `protocol.ts` directly, which is what lets the drift check assert against the real exported list rather than a transcription of it.

## Follow-up

The status vocabulary is still written by hand in two languages; this branch makes the two agree and adds a test that fails when they stop agreeing, but the copies are still copies. Generating the TypeScript from the Rust — for the whole wire protocol, not just this enum — is a separate PR off `main`. Note that generated *types* alone would not have caught this bug: it lived in a runtime check, so the generator has to emit the runtime array too, which is the shape `RUN_STATUSES` is already in.

