### PR TITLE
Make `make dev` install dependencies it does not have

### DIFF
--- a/web/dev.sh
+++ b/web/dev.sh
@@ -68,12 +68,46 @@ open_url() {
   fi
 }
 
+# Checked here because nothing else checks it: npm ignores `engines` unless the
+# project opts into engine-strict, so an old Node installs cleanly and then
+# fails inside a dependency, as a SyntaxError about some export that release
+# does not have. That trace says nothing about Node versions.
+if ! command -v node >/dev/null 2>&1; then
+  printf 'Node is not installed; Mission Control needs Node. See web/README.md.\n' >&2
+  exit 1
+fi
+required_node=$(node -p "require('$script_dir/package.json').engines.node.replace(/[^0-9.]/g, '')")
+current_node=$(node -p 'process.versions.node')
+if [[ $(printf '%s\n%s\n' "$required_node" "$current_node" | sort -V | head -1) != "$required_node" ]]; then
+  printf 'Node %s is too old; Mission Control needs >=%s. Yours: %s\n' \
+    "$current_node" "$required_node" "$(command -v node)" >&2
+  exit 1
+fi
+
 printf 'Building the runtime...\n'
 (cd "$repo_root" && cargo build --quiet --bin omar)
 
+# Reinstalled when the manifests are newer than the tree, not just when the
+# tree is missing: a pull that adds a dependency leaves node_modules in place
+# but incomplete, and the failure shows up as a module the dev server cannot
+# resolve rather than as anything about installing.
+needs_install=0
 if [[ ! -d "$script_dir/node_modules" ]]; then
+  needs_install=1
+else
+  for manifest in package.json package-lock.json; do
+    if [[ "$script_dir/$manifest" -nt "$script_dir/node_modules" ]]; then
+      needs_install=1
+    fi
+  done
+fi
+
+if ((needs_install)); then
   printf 'Installing web dependencies...\n'
   (cd "$script_dir" && npm install --silent)
+  # npm only touches node_modules when it changes something, so stamp it to
+  # keep this from reinstalling on every run.
+  touch "$script_dir/node_modules"
 fi
 
 printf 'Starting omar serve on %s...\n' "$serve_address"

--- a/web/dev.sh
+++ b/web/dev.sh
@@ -76,7 +76,10 @@ if ! command -v node >/dev/null 2>&1; then
   printf 'Node is not installed; Mission Control needs Node. See web/README.md.\n' >&2
   exit 1
 fi
-required_node=$(node -p "require('$script_dir/package.json').engines.node.replace(/[^0-9.]/g, '')")
+# Matched rather than stripped of everything non-numeric: a range with two
+# versions in it -- ">=22.13.0 <25" -- strips to "22.13.025", which is not any
+# version, and compares wrong without ever looking wrong.
+required_node=$(node -p "require('$script_dir/package.json').engines.node.match(/[0-9]+(\.[0-9]+)*/)[0]")
 current_node=$(node -p 'process.versions.node')
 if [[ $(printf '%s\n%s\n' "$required_node" "$current_node" | sort -V | head -1) != "$required_node" ]]; then
   printf 'Node %s is too old; Mission Control needs >=%s. Yours: %s\n' \

--- a/web/tests/dev-script.test.sh
+++ b/web/tests/dev-script.test.sh
@@ -34,6 +34,44 @@ fail() {
   exit 1
 }
 
+# The Node floor, checked with a stub rather than a real old Node: npm does not
+# enforce `engines`, so before this guard an old Node got all the way to a
+# SyntaxError inside a dependency that said nothing about Node versions.
+printf 'Checking the Node version guard...\n'
+stub_dir=$(mktemp -d)
+real_node=$(command -v node)
+cat >"$stub_dir/node" <<EOF
+#!/usr/bin/env bash
+# Only the version lookup is faked. The manifest read has to stay real, or this
+# would be testing the stub instead of the comparison.
+if [[ \${2-} == *process.versions.node* ]]; then
+  printf '20.20.0\n'
+  exit 0
+fi
+exec "$real_node" "\$@"
+EOF
+chmod +x "$stub_dir/node"
+
+guard_log=$(mktemp)
+if PATH="$stub_dir:$PATH" OMAR_DEV_OPEN=0 "$web_dir/dev.sh" >"$guard_log" 2>&1; then
+  printf 'FAIL: dev.sh ran on Node 20 instead of refusing\n' >&2
+  cat "$guard_log" >&2
+  rm -rf "$stub_dir" "$guard_log"
+  exit 1
+fi
+grep -q 'Node 20.20.0 is too old' "$guard_log" || {
+  printf 'FAIL: the guard refused without saying the Node version was why\n' >&2
+  cat "$guard_log" >&2
+  rm -rf "$stub_dir" "$guard_log"
+  exit 1
+}
+rm -rf "$stub_dir" "$guard_log"
+
+# A pull that adds a dependency leaves node_modules present but incomplete, so
+# a manifest newer than the tree has to reinstall. Touching package.json is
+# exactly what that pull looks like to the script.
+touch "$web_dir/package.json"
+
 printf 'Starting dev.sh...\n'
 OMAR_DEV_OPEN=0 \
   OMAR_SERVE_ADDRESS="$serve_address" \
@@ -56,6 +94,9 @@ curl -fsS -o /dev/null "$web_url/" || fail "Mission Control did not answer"
 # demo-mode shell here means the two started without being pointed at anything.
 curl -fsS "$web_url/" | grep -q "$serve_address" \
   || fail "the page does not name the daemon, so it launched in demo mode"
+
+grep -q 'Installing web dependencies' "$log" \
+  || fail "a manifest newer than node_modules did not trigger an install"
 
 printf 'Both answered. Stopping...\n'
 kill "$dev_pid"

--- a/web/tests/dev-script.test.sh
+++ b/web/tests/dev-script.test.sh
@@ -70,6 +70,12 @@ rm -rf "$stub_dir" "$guard_log"
 # A pull that adds a dependency leaves node_modules present but incomplete, so
 # a manifest newer than the tree has to reinstall. Touching package.json is
 # exactly what that pull looks like to the script.
+#
+# The tree has to exist and has to be older, or the assertion below holds for
+# the behaviour this replaced as well: a missing node_modules installs either
+# way, and that is not the path under test.
+[[ -d "$web_dir/node_modules" ]] || (cd "$web_dir" && npm install --silent)
+touch -t 202001010000 "$web_dir/node_modules"
 touch "$web_dir/package.json"
 
 printf 'Starting dev.sh...\n'


### PR DESCRIPTION
Two reasons `make dev` needed a `make install` first.

## The tree is never refreshed

`web/dev.sh` installed web dependencies only when `node_modules` was **missing**:

```bash
if [[ ! -d "$script_dir/node_modules" ]]; then
```

Once the tree existed it was never touched again, so a pull that added a dependency left it in place and incomplete. That surfaced as a module the dev server could not resolve, and the only thing that fixed it was `make install` — whose `web-bundle` target runs `npm ci`.

Now it installs when `package.json` or `package-lock.json` is newer than the tree, and stamps the tree afterwards so it does not reinstall on every run (npm only touches `node_modules` when it changes something). `npm install`, not `npm ci`, is deliberate: `ci` wipes the tree and hard-fails when the manifest and lockfile disagree, which is the normal state while adding a dependency locally.

## The Node floor is declared but not enforced

On Node 20, `make dev` died inside a dependency:

```
node_modules/vinext/dist/routing/file-matcher.js:2
import { glob } from "node:fs/promises";
         ^^^^
SyntaxError: The requested module 'node:fs/promises' does not provide an export named 'glob'
```

`fsPromises.glob` landed in Node 22.0.0. The repo already asks for it — `package.json` declares `"engines": { "node": ">=22.13.0" }` and every `setup-node` in CI pins 22 — but npm ignores `engines` without `engine-strict`, so an old Node installs cleanly and fails much later, in someone else's code, with a trace that never mentions Node versions.

`dev.sh` now checks the floor before doing anything, reading it from `package.json` so the two cannot drift:

```
Node 20.20.0 is too old; Mission Control needs >=22.13.0. Yours: /usr/bin/node
```

## Tests

Both paths go into the `dev-script` smoke test CI already runs:

- a stubbed Node reporting 20.20.0 must be refused, and the refusal must name the version as the reason
- `touch package.json` before the run — what a dependency-adding pull looks like to the script — must produce an install

Verified locally: the guard exits 1 before the cargo build with the message above, accepts 22.13.0/24.1.0 and rejects 20.20.0/22.12.0. The full smoke test was left to CI rather than run here, since it starts a daemon and tmux panes on a working machine.

One known limit: bash `-nt` compares whole seconds, so a manifest changed in the same second as the install stamp is missed. Real trees are hours or days old, and it self-corrects on the next run.

## Review follow-up

- The Node floor is read out of `engines.node` by matching a version rather than stripping every non-digit. The strip is only right while the field holds one version: `">=22.13.0 <25"` strips to `"22.13.025"`, which is not a version and compares wrong without looking wrong.
- The install assertion now establishes what it is asserting against. It touched `package.json` without ensuring `node_modules` existed and was older, so a missing tree would have made it pass against the behaviour this PR replaces. The tree is installed if absent and backdated before the touch. Checked both ways with a stub `cargo`: the setup installs under this branch and does not under the old `[[ ! -d node_modules ]]`.
- `sort -V` is kept. It is BSD sort's flag too — macOS ships `2.3-Apple (197)`, whose `man sort` documents `-V, --version-sort`. Ran the guard on macOS 26 against stubbed Nodes: 20.20.0 and 22.12.0 refused, 22.13.0 and 24.1.0 accepted. `22.12.0` vs `22.13.0` is the pair a lexicographic sort gets backwards, so the flag is doing the comparison, not being ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7nmTPtmEfL1BTZ3Wingr6

