### PR TITLE
Give each team its own workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Terminal UI
 - **Heterogeneity**: Let `claude`, `codex`, and other agents collaborate as a team.
 - **Full control**: Talk to and control any subagent you want.
 - **Life span**: Long-running or ephemeral agents, your choice.
+- **Isolation**: Give each team its own git worktree or docker container. See [docs/isolation.md](docs/isolation.md).
 - **Customization**: Support all `tmux` commands you love.
 
 Other features include messaging systems integration (e.g., Slack), computer use, and more.

--- a/docs/agents.Dockerfile
+++ b/docs/agents.Dockerfile
@@ -1,0 +1,30 @@
+# Example image for `[isolation] mode = "container"`.
+#
+# Container isolation runs each agent inside the image, so the image must carry
+# every backend the team uses. Adjust the install list to your backends and
+# pin versions for a reproducible team.
+#
+#   docker build -t omar-agents:latest -f docs/agents.Dockerfile .
+#   # then set image = "omar-agents:latest" under [isolation]
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        ripgrep \
+        nodejs \
+        npm \
+    && rm -rf /var/lib/apt/lists/*
+
+# claude, codex, opencode. cursor and agy install through their own scripts;
+# see each vendor's docs.
+RUN npm install -g \
+        @anthropic-ai/claude-code \
+        @openai/codex \
+        opencode-ai
+
+# OMAR mounts the worktree, ~/.omar, the omar binary and your credential dirs
+# at their host paths and sets HOME to your host home, so nothing here needs to
+# know where they live.
+CMD ["sleep", "infinity"]

--- a/docs/isolation.md
+++ b/docs/isolation.md
@@ -1,0 +1,97 @@
+# Team isolation
+
+The team is the unit. Agents in one team share a workspace; agents in different
+teams never do.
+
+```toml
+# ~/.omar/config.toml
+[isolation]
+mode = "worktree"                 # none | worktree | container
+image = "debian:bookworm-slim"    # container mode only
+credential_mounts = ["~/.claude", "~/.codex"]
+```
+
+Per run: `omar run team.omar --isolation worktree`.
+
+Applies to deployed teams. The EA's own pane is not isolated — it orchestrates
+teams rather than belonging to one.
+
+## Modes
+
+| Mode | Each team gets | Needs |
+|---|---|---|
+| `none` | nothing; all teams share `[agent] default_workdir` | — |
+| `worktree` | a git worktree, on its own branch | a git repo |
+| `container` | that worktree, mounted in its own container | docker |
+
+`none` is the default and the previous behaviour.
+
+## worktree
+
+Cut from `[agent] default_workdir`'s repository into the team's own state
+directory:
+
+```
+~/.omar/ea/0/topologies/alpha/worktree/     branch omar/alpha/<run>
+~/.omar/ea/0/topologies/beta/worktree/      branch omar/beta/<run>
+```
+
+Every agent in `alpha` launches there. Writes are shared inside the team and
+invisible to `beta`.
+
+Removed when a run completes or is stopped. **Kept** when a run fails or is
+cancelled — that is when you need to see what the team did. The next deploy of
+the same team reclaims the path.
+
+Two limits worth knowing:
+
+- **A worktree is a clean checkout.** No `.env`, no `node_modules`, no build
+  cache. Agents that need them will fail until you put them there.
+- **It is not a security boundary.** The object database is shared, so a team
+  can read another team's branches, and nothing stops an agent walking out of
+  the directory. It separates working trees, which buys coordination.
+
+## container
+
+Everything worktree does, plus a docker container per team. Agent panes run
+`docker exec` into it, so tmux, `omar list` and attach all work unchanged.
+
+Host paths are mounted at the same absolute paths inside, and `HOME` points at
+your host home, so `~/.claude` and the absolute paths OMAR bakes into a launch
+command mean the same thing on both sides.
+
+Mounted: the team worktree, `~/.omar`, the `omar` binary, and every existing
+path in `credential_mounts`. A path that does not exist is skipped rather than
+created.
+
+**The default image carries no agent CLIs.** Container mode probes for each
+backend the team uses and refuses to deploy if one is missing, naming it. Point
+`image` at something that has them:
+
+```dockerfile
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl git ripgrep nodejs npm \
+    && rm -rf /var/lib/apt/lists/*
+RUN npm install -g @anthropic-ai/claude-code @openai/codex opencode-ai
+```
+
+```bash
+docker build -t omar-agents:latest -f docs/agents.Dockerfile .
+```
+
+Then set `image = "omar-agents:latest"`.
+
+### Known limits
+
+- **opencode's side channel does not survive.** OMAR reaches opencode over a
+  loopback HTTP port, and the container has its own network namespace, so
+  provisioning times out and delivery falls back to typing into the pane. The
+  other backends use unix sockets or files under mounted paths and are
+  unaffected.
+- **Credentials are shared within the team.** Every agent in the container can
+  read every mounted login. A team container is a trust boundary, not a
+  security one. Narrow `credential_mounts` to what the team actually needs.
+- **The tmux server stays on the host.** An agent that can reach OMAR's MCP
+  surface can still ask for a pane outside the container. Container mode
+  contains what an agent does in its own pane, not what it can ask OMAR for.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1979,6 +1979,7 @@ mod tests {
             },
             metrics: MetricsConfig::default(),
             slack_bridge: crate::config::SlackBridgeConfig::default(),
+            isolation: crate::config::IsolationConfig::default(),
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,9 @@ pub struct Config {
 
     #[serde(default)]
     pub slack_bridge: SlackBridgeConfig,
+
+    #[serde(default)]
+    pub isolation: IsolationConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -71,6 +74,39 @@ pub struct AgentConfig {
     /// Default working directory
     #[serde(default = "default_workdir")]
     pub default_workdir: String,
+}
+
+/// How a deployment's agents are separated from other deployments.
+///
+/// The team is the unit: agents in one team share a workspace, agents in
+/// different teams never do.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IsolationConfig {
+    /// `none`, `worktree`, or `container`.
+    #[serde(default = "default_isolation_mode")]
+    pub mode: String,
+
+    /// Image container mode runs agents in. The default carries no agent CLIs,
+    /// so a team using one fails its preflight until this points at an image
+    /// that has them — see docs/isolation.md.
+    #[serde(default = "default_isolation_image")]
+    pub image: String,
+
+    /// Host paths mounted into the container so backends find their logins.
+    /// A leading `~/` expands to the operator's home; a path that does not
+    /// exist is skipped rather than created.
+    #[serde(default = "default_credential_mounts")]
+    pub credential_mounts: Vec<String>,
+}
+
+impl Default for IsolationConfig {
+    fn default() -> Self {
+        Self {
+            mode: default_isolation_mode(),
+            image: default_isolation_image(),
+            credential_mounts: default_credential_mounts(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -193,6 +229,28 @@ pub fn resolve_backend(name: &str) -> Result<String, String> {
 
 fn default_workdir() -> String {
     ".".to_string()
+}
+
+fn default_isolation_mode() -> String {
+    "none".to_string()
+}
+
+fn default_isolation_image() -> String {
+    "debian:bookworm-slim".to_string()
+}
+
+/// Every backend's login store. Mounting all of them is what makes a
+/// heterogeneous team work out of the box; an operator who wants a narrower
+/// boundary sets `credential_mounts` to the subset their team needs.
+fn default_credential_mounts() -> Vec<String> {
+    vec![
+        "~/.claude".to_string(),
+        "~/.claude.json".to_string(),
+        "~/.codex".to_string(),
+        "~/.cursor".to_string(),
+        "~/.gemini".to_string(),
+        "~/.local/share/opencode".to_string(),
+    ]
 }
 
 impl Default for DashboardConfig {

--- a/src/isolation.rs
+++ b/src/isolation.rs
@@ -1,0 +1,708 @@
+//! Per-team workspace isolation.
+//!
+//! A team is the unit. Every agent in a team shares one workspace; agents in
+//! different teams never share one. Three modes:
+//!
+//! - `none`: what OMAR did before — every agent launches in the configured
+//!   workdir, teams share it.
+//! - `worktree`: a git worktree per deployment, cut from the configured
+//!   workdir's repository onto a branch named for the run.
+//! - `container`: the worktree, plus a docker container per deployment that
+//!   mounts it. Agent panes run `docker exec` into that container.
+//!
+//! Worktree isolation separates working trees, not repositories: the object
+//! database is shared, so a team can read another team's branches. It buys
+//! coordination, not security. Container isolation adds an OS boundary around
+//! the team, but OMAR's tmux server stays outside it, so an agent that can
+//! reach the MCP surface can still ask for a pane on the host.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{bail, Context, Result};
+
+use crate::config::IsolationConfig;
+use crate::manager::shell_single_quote;
+
+/// Which boundary a deployment runs behind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    None,
+    Worktree,
+    Container,
+}
+
+impl Mode {
+    pub fn parse(raw: &str) -> Result<Mode> {
+        match raw.trim() {
+            "none" => Ok(Mode::None),
+            "worktree" => Ok(Mode::Worktree),
+            "container" => Ok(Mode::Container),
+            other => bail!(
+                "unknown isolation mode '{}'. Supported: none, worktree, container",
+                other
+            ),
+        }
+    }
+}
+
+/// A prepared workspace, owned by one deployment.
+///
+/// `workdir` is a host path in every mode. Container mode mounts the worktree
+/// at the same absolute path inside the container, so a path that OMAR baked
+/// into a launch command — the MCP config, the system prompt, the omar binary
+/// — resolves identically on both sides and needs no translation.
+#[derive(Debug, Clone)]
+pub struct Workspace {
+    workdir: String,
+    worktree: Option<PathBuf>,
+    container: Option<String>,
+}
+
+impl Workspace {
+    /// Where agents launch. Absolute in every mode but `none`, which passes
+    /// the operator's configured value through untouched.
+    pub fn workdir(&self) -> &str {
+        &self.workdir
+    }
+
+    /// Wrap an agent launch command for this workspace.
+    ///
+    /// Only container mode rewrites anything. The command is handed to the
+    /// container's shell as a single quoted argument, so the quoting a backend
+    /// command already carries — codex's `-c key='"value"'` — survives.
+    pub fn wrap_command(&self, command: &str) -> String {
+        match &self.container {
+            Some(name) => format!(
+                "docker exec -it -w {} {} sh -lc {}",
+                shell_single_quote(&self.workdir),
+                shell_single_quote(name),
+                shell_single_quote(command)
+            ),
+            None => command.to_string(),
+        }
+    }
+
+    /// Release the workspace.
+    ///
+    /// `keep` holds the worktree on disk for a run that failed or was
+    /// cancelled, which is exactly when an operator needs to look at what the
+    /// team did. The container goes either way: it is reconstructible from the
+    /// worktree, and a stopped run should not leave one running.
+    pub fn teardown(&self, keep: bool) -> Vec<String> {
+        let mut failures = Vec::new();
+        if let Some(name) = &self.container {
+            if let Err(error) = docker(&["rm", "-f", name]) {
+                failures.push(format!("container {name}: {error:#}"));
+            }
+        }
+        if keep {
+            return failures;
+        }
+        if let Some(path) = &self.worktree {
+            if let Err(error) = remove_worktree(path) {
+                failures.push(format!("worktree {}: {error:#}", path.display()));
+            }
+        }
+        failures
+    }
+}
+
+/// Build the workspace a deployment runs in.
+///
+/// `source` is the operator's configured workdir — the repository a worktree
+/// is cut from. `runtime_dir` is the team's own state directory, which already
+/// holds the deployment record and logs, so the worktree lands beside them and
+/// `omar stop` needs no new path to know about.
+pub fn prepare(
+    settings: &IsolationConfig,
+    ea_id: crate::ea::EaId,
+    team: &str,
+    deployment_id: &str,
+    source: &str,
+    runtime_dir: &Path,
+    backends: &[String],
+) -> Result<Workspace> {
+    let mode = Mode::parse(&settings.mode)?;
+    if mode == Mode::None {
+        return Ok(Workspace {
+            workdir: source.to_string(),
+            worktree: None,
+            container: None,
+        });
+    }
+
+    let path = runtime_dir.join("worktree");
+    let branch = branch_name(team, deployment_id);
+    create_worktree(source, &path, &branch)?;
+    let workdir = path.to_string_lossy().into_owned();
+
+    if mode == Mode::Worktree {
+        return Ok(Workspace {
+            workdir,
+            worktree: Some(path),
+            container: None,
+        });
+    }
+
+    let name = container_name(ea_id, team);
+    match start_container(settings, &name, &workdir, backends) {
+        Ok(()) => Ok(Workspace {
+            workdir,
+            worktree: Some(path),
+            container: Some(name),
+        }),
+        Err(error) => {
+            // The worktree exists but the run will not start. Leaving it would
+            // strand a branch nobody asked for.
+            let _ = remove_worktree(&path);
+            Err(error)
+        }
+    }
+}
+
+/// The branch a deployment's worktree checks out.
+///
+/// Namespaced by team and run so a second deployment of the same team never
+/// collides with a branch the first one still holds — git refuses to check out
+/// one branch in two worktrees, and that refusal would surface as a confusing
+/// deploy failure rather than the isolation it actually is.
+pub fn branch_name(team: &str, deployment_id: &str) -> String {
+    format!("omar/{}/{}", sanitize(team), short_id(deployment_id))
+}
+
+/// The container a team runs in.
+///
+/// Scoped to the team rather than the run, unlike the branch: OMAR already
+/// refuses a second live run of one team, and a stable name means a container
+/// orphaned by a runner that died is reclaimed by the next deploy instead of
+/// leaking. The EA id is in it because two EAs may each have a team `alpha`.
+pub fn container_name(ea_id: crate::ea::EaId, team: &str) -> String {
+    format!("omar-{}-{}", ea_id, sanitize(team))
+}
+
+/// Keep only characters both git refs and docker names accept, so one
+/// sanitizer serves both and a team name can't inject an argument.
+fn sanitize(raw: &str) -> String {
+    let cleaned: String = raw
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let trimmed = cleaned.trim_matches('-').to_string();
+    if trimmed.is_empty() {
+        "team".to_string()
+    } else {
+        trimmed
+    }
+}
+
+/// Deployment ids are uuids; the first segment is enough to separate runs and
+/// keeps the branch and container names readable.
+fn short_id(deployment_id: &str) -> String {
+    let head: String = deployment_id
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .take(8)
+        .collect();
+    if head.is_empty() {
+        "run".to_string()
+    } else {
+        head
+    }
+}
+
+fn create_worktree(source: &str, path: &Path, branch: &str) -> Result<()> {
+    let repo = std::fs::canonicalize(source)
+        .with_context(|| format!("isolation source directory '{source}' does not exist"))?;
+    if !is_git_repo(&repo) {
+        bail!(
+            "isolation needs a git repository: '{}' is not inside one. \
+             Set [agent] default_workdir to a repository, or use isolation mode 'none'.",
+            repo.display()
+        );
+    }
+    // A previous run of this team may have left one behind — a failed run
+    // keeps its worktree on purpose. Clear it before reusing the path.
+    if path.exists() {
+        remove_worktree(path)?;
+    }
+    // Registrations can outlive their directory (a manual `rm -rf`), and git
+    // refuses to add a worktree whose path it still has on file.
+    let _ = git(&repo, &["worktree", "prune"]);
+    // `-B` rather than `-b`: a branch left over from a run whose worktree was
+    // already removed must not block the new one.
+    git(
+        &repo,
+        &[
+            "worktree",
+            "add",
+            "-B",
+            branch,
+            &path.to_string_lossy(),
+            "HEAD",
+        ],
+    )
+    .with_context(|| format!("create worktree for branch '{branch}'"))?;
+    Ok(())
+}
+
+fn remove_worktree(path: &Path) -> Result<()> {
+    // Resolve the repository from the worktree itself: the caller's source
+    // directory is not reachable from teardown, and a worktree always knows
+    // its own common directory.
+    let repo = match git_common_dir(path) {
+        Some(dir) => dir,
+        None => {
+            // Not a live worktree any more. Nothing to unregister.
+            if path.exists() {
+                std::fs::remove_dir_all(path).ok();
+            }
+            return Ok(());
+        }
+    };
+    git(
+        &repo,
+        &["worktree", "remove", "--force", &path.to_string_lossy()],
+    )
+    .with_context(|| format!("remove worktree '{}'", path.display()))?;
+    Ok(())
+}
+
+fn is_git_repo(dir: &Path) -> bool {
+    git(dir, &["rev-parse", "--git-dir"]).is_ok()
+}
+
+/// The main repository a worktree belongs to, or `None` if the path is not a
+/// worktree at all.
+fn git_common_dir(worktree: &Path) -> Option<PathBuf> {
+    if !worktree.exists() {
+        return None;
+    }
+    let common = git(
+        worktree,
+        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    )
+    .ok()?;
+    let common = PathBuf::from(common.trim());
+    // `.../repo/.git` -> `.../repo`
+    common.parent().map(Path::to_path_buf)
+}
+
+fn git(dir: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .context("run git")?;
+    if !output.status.success() {
+        bail!(
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Start the team's container and prove the backends it must run are present.
+fn start_container(
+    settings: &IsolationConfig,
+    name: &str,
+    workdir: &str,
+    backends: &[String],
+) -> Result<()> {
+    if Command::new("docker")
+        .arg("--version")
+        .output()
+        .map(|out| !out.status.success())
+        .unwrap_or(true)
+    {
+        bail!("isolation mode 'container' needs docker on PATH");
+    }
+    // A container left by a run that died before teardown holds the name.
+    let _ = docker(&["rm", "-f", name]);
+
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
+    let home = home.to_string_lossy().into_owned();
+    let mut args: Vec<String> = vec![
+        "run".into(),
+        "-d".into(),
+        "--name".into(),
+        name.into(),
+        // Host paths are mounted at the same absolute paths inside, and HOME
+        // points at the host home, so `~/.claude` and the absolute paths baked
+        // into a launch command mean the same thing on both sides.
+        "-e".into(),
+        format!("HOME={home}"),
+        "-w".into(),
+        workdir.into(),
+        "-v".into(),
+        format!("{workdir}:{workdir}"),
+    ];
+    for mount in mount_paths(settings, &home) {
+        args.push("-v".into());
+        args.push(format!("{mount}:{mount}"));
+    }
+    args.push(settings.image.clone());
+    // Keep the container alive with no agent in it: panes join later with
+    // `docker exec`, and each pane's lifetime is its own.
+    args.extend(["sleep".to_string(), "infinity".to_string()]);
+
+    let borrowed: Vec<&str> = args.iter().map(String::as_str).collect();
+    docker(&borrowed)
+        .with_context(|| format!("start container from image '{}'", settings.image))?;
+
+    if let Err(error) = verify_backends(name, backends, &settings.image) {
+        let _ = docker(&["rm", "-f", name]);
+        return Err(error);
+    }
+    Ok(())
+}
+
+/// Every host path the container needs mounted, deduplicated and existing.
+///
+/// A mount of a path that does not exist makes docker create an empty
+/// directory owned by root on the host, so a typo in `credential_mounts`
+/// would litter the operator's home rather than fail.
+fn mount_paths(settings: &IsolationConfig, home: &str) -> Vec<String> {
+    let mut paths: Vec<String> = Vec::new();
+    // OMAR's own state: the MCP config, the system prompt and the context file
+    // a pane's sidecar reads are all under it, by absolute path.
+    if let Some(dir) = dirs::home_dir() {
+        paths.push(dir.join(".omar").to_string_lossy().into_owned());
+    }
+    // The MCP server a backend launches is this binary.
+    if let Ok(exe) = std::env::current_exe() {
+        paths.push(exe.to_string_lossy().into_owned());
+    }
+    for raw in &settings.credential_mounts {
+        paths.push(expand_home(raw, home));
+    }
+    let mut seen = std::collections::BTreeSet::new();
+    paths
+        .into_iter()
+        .filter(|path| Path::new(path).exists())
+        .filter(|path| seen.insert(path.clone()))
+        .collect()
+}
+
+fn expand_home(raw: &str, home: &str) -> String {
+    match raw.strip_prefix("~/") {
+        Some(rest) => format!("{home}/{rest}"),
+        None => raw.to_string(),
+    }
+}
+
+/// Fail a container deploy that would leave every pane at "command not found".
+///
+/// The default image carries no agent CLIs, so this is the common case rather
+/// than a defensive one, and the message has to say what to do about it.
+fn verify_backends(container: &str, backends: &[String], image: &str) -> Result<()> {
+    let mut missing: Vec<&str> = Vec::new();
+    for backend in backends {
+        let probe = format!("command -v {}", shell_single_quote(backend));
+        if docker(&["exec", container, "sh", "-lc", &probe]).is_err() {
+            missing.push(backend);
+        }
+    }
+    if missing.is_empty() {
+        return Ok(());
+    }
+    bail!(
+        "image '{}' has no {} on PATH. Container isolation runs each agent inside \
+         the image, so it must carry every backend the team uses. Set [isolation] image \
+         to one that does — see docs/isolation.md for an example Dockerfile.",
+        image,
+        missing.join(", ")
+    )
+}
+
+fn docker(args: &[&str]) -> Result<String> {
+    let output = Command::new("docker")
+        .args(args)
+        .output()
+        .context("run docker")?;
+    if !output.status.success() {
+        bail!(
+            "docker {} failed: {}",
+            args.first().copied().unwrap_or_default(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn settings(mode: &str) -> IsolationConfig {
+        IsolationConfig {
+            mode: mode.to_string(),
+            image: "debian:bookworm-slim".to_string(),
+            credential_mounts: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn mode_parses_the_three_supported_values() {
+        assert_eq!(Mode::parse("none").unwrap(), Mode::None);
+        assert_eq!(Mode::parse("worktree").unwrap(), Mode::Worktree);
+        assert_eq!(Mode::parse("container").unwrap(), Mode::Container);
+        assert!(Mode::parse("vm").is_err());
+    }
+
+    #[test]
+    fn none_passes_the_configured_workdir_through_untouched() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = prepare(
+            &settings("none"),
+            0,
+            "alpha",
+            "1234abcd-0000",
+            ".",
+            temp.path(),
+            &["claude".to_string()],
+        )
+        .unwrap();
+        assert_eq!(workspace.workdir(), ".");
+        // And nothing wraps the launch: the pane runs on the host as before.
+        assert_eq!(workspace.wrap_command("claude"), "claude");
+    }
+
+    #[test]
+    fn a_command_is_unchanged_without_a_container() {
+        let workspace = Workspace {
+            workdir: "/w".to_string(),
+            worktree: None,
+            container: None,
+        };
+        assert_eq!(workspace.wrap_command("claude --foo"), "claude --foo");
+    }
+
+    #[test]
+    fn a_container_command_survives_the_quoting_a_backend_already_carries() {
+        let workspace = Workspace {
+            workdir: "/w/one".to_string(),
+            worktree: None,
+            container: Some("omar-alpha-1234abcd".to_string()),
+        };
+        let wrapped =
+            workspace.wrap_command("codex --no-alt-screen -c model_reasoning_effort='\"high\"'");
+        assert_eq!(
+            wrapped,
+            "docker exec -it -w '/w/one' 'omar-alpha-1234abcd' sh -lc \
+             'codex --no-alt-screen -c model_reasoning_effort='\\''\"high\"'\\'''"
+        );
+        // And the wrapper is what a shell would hand back as one argument.
+        let echoed = Command::new("sh")
+            .args([
+                "-lc",
+                &format!(
+                    "printf '%s' {}",
+                    shell_single_quote(
+                        "codex --no-alt-screen -c model_reasoning_effort='\"high\"'",
+                    )
+                ),
+            ])
+            .output()
+            .unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&echoed.stdout),
+            "codex --no-alt-screen -c model_reasoning_effort='\"high\"'"
+        );
+    }
+
+    #[test]
+    fn a_branch_is_namespaced_by_team_and_run() {
+        assert_eq!(branch_name("alpha", "1234abcd-ef"), "omar/alpha/1234abcd");
+        // Two runs of one team never share a branch, or the second would
+        // force-reset the first one's commits away.
+        assert_ne!(
+            branch_name("alpha", "1234abcd"),
+            branch_name("alpha", "9999zzzz")
+        );
+    }
+
+    #[test]
+    fn a_container_is_named_for_the_team_so_a_stale_one_is_reclaimed() {
+        assert_eq!(container_name(0, "alpha"), "omar-0-alpha");
+        // Stable across runs of the same team...
+        assert_eq!(container_name(0, "alpha"), container_name(0, "alpha"));
+        // ...and distinct for the same team name under another EA.
+        assert_ne!(container_name(0, "alpha"), container_name(1, "alpha"));
+    }
+
+    #[test]
+    fn a_team_name_cannot_inject_a_git_or_docker_argument() {
+        assert_eq!(branch_name("--force ; rm", "abc"), "omar/force---rm/abc");
+        assert_eq!(container_name(0, "../../etc"), "omar-0-etc");
+        assert_eq!(branch_name("", "abc"), "omar/team/abc");
+    }
+
+    #[test]
+    fn a_credential_mount_expands_a_leading_tilde() {
+        assert_eq!(expand_home("~/.claude", "/home/x"), "/home/x/.claude");
+        assert_eq!(expand_home("/etc/ssl", "/home/x"), "/etc/ssl");
+    }
+
+    #[test]
+    fn mounts_skip_paths_that_do_not_exist() {
+        let temp = tempfile::tempdir().unwrap();
+        let present = temp.path().join("present");
+        std::fs::create_dir(&present).unwrap();
+        let mut config = settings("container");
+        config.credential_mounts = vec![
+            present.to_string_lossy().into_owned(),
+            temp.path().join("absent").to_string_lossy().into_owned(),
+        ];
+        let mounts = mount_paths(&config, "/home/x");
+        assert!(mounts.contains(&present.to_string_lossy().into_owned()));
+        assert!(!mounts.iter().any(|m| m.ends_with("absent")));
+    }
+
+    #[cfg(unix)]
+    fn repo_with_a_commit() -> tempfile::TempDir {
+        let temp = tempfile::tempdir().unwrap();
+        let run = |args: &[&str]| {
+            let ok = Command::new("git")
+                .current_dir(temp.path())
+                .args(args)
+                .output()
+                .unwrap()
+                .status
+                .success();
+            assert!(ok, "git {args:?} failed");
+        };
+        run(&["init", "-q"]);
+        run(&["config", "user.email", "test@example.com"]);
+        run(&["config", "user.name", "test"]);
+        std::fs::write(temp.path().join("file.txt"), "one").unwrap();
+        run(&["add", "."]);
+        run(&["commit", "-qm", "first"]);
+        temp
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn worktree_mode_gives_each_team_its_own_checkout_of_one_repo() {
+        let repo = repo_with_a_commit();
+        let source = repo.path().to_string_lossy().into_owned();
+        let state = tempfile::tempdir().unwrap();
+        let alpha_dir = state.path().join("alpha");
+        let beta_dir = state.path().join("beta");
+        std::fs::create_dir_all(&alpha_dir).unwrap();
+        std::fs::create_dir_all(&beta_dir).unwrap();
+
+        let alpha = prepare(
+            &settings("worktree"),
+            0,
+            "alpha",
+            "aaaaaaaa",
+            &source,
+            &alpha_dir,
+            &[],
+        )
+        .unwrap();
+        let beta = prepare(
+            &settings("worktree"),
+            0,
+            "beta",
+            "bbbbbbbb",
+            &source,
+            &beta_dir,
+            &[],
+        )
+        .unwrap();
+
+        // Separate directories, both real checkouts of the same commit.
+        assert_ne!(alpha.workdir(), beta.workdir());
+        assert_eq!(
+            std::fs::read_to_string(Path::new(alpha.workdir()).join("file.txt")).unwrap(),
+            "one"
+        );
+        assert_eq!(
+            std::fs::read_to_string(Path::new(beta.workdir()).join("file.txt")).unwrap(),
+            "one"
+        );
+
+        // A write by one team is invisible to the other.
+        std::fs::write(Path::new(alpha.workdir()).join("file.txt"), "alpha").unwrap();
+        assert_eq!(
+            std::fs::read_to_string(Path::new(beta.workdir()).join("file.txt")).unwrap(),
+            "one"
+        );
+
+        // Teardown unregisters the worktree rather than orphaning it.
+        assert!(alpha.teardown(false).is_empty());
+        assert!(!Path::new(alpha.workdir()).exists());
+        let listed = git(repo.path(), &["worktree", "list"]).unwrap();
+        assert!(
+            !listed.contains("alpha"),
+            "worktree still registered: {listed}"
+        );
+        assert!(beta.teardown(false).is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_failed_run_keeps_its_worktree_for_inspection() {
+        let repo = repo_with_a_commit();
+        let state = tempfile::tempdir().unwrap();
+        let workspace = prepare(
+            &settings("worktree"),
+            0,
+            "alpha",
+            "aaaaaaaa",
+            &repo.path().to_string_lossy(),
+            state.path(),
+            &[],
+        )
+        .unwrap();
+        std::fs::write(Path::new(workspace.workdir()).join("evidence.txt"), "why").unwrap();
+
+        assert!(workspace.teardown(true).is_empty());
+
+        assert!(Path::new(workspace.workdir()).join("evidence.txt").exists());
+        // And the next run of the same team reclaims the path rather than
+        // failing on it.
+        let next = prepare(
+            &settings("worktree"),
+            0,
+            "alpha",
+            "cccccccc",
+            &repo.path().to_string_lossy(),
+            state.path(),
+            &[],
+        )
+        .unwrap();
+        assert!(!Path::new(next.workdir()).join("evidence.txt").exists());
+        assert!(next.teardown(false).is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn worktree_mode_refuses_a_source_that_is_not_a_repository() {
+        let plain = tempfile::tempdir().unwrap();
+        let state = tempfile::tempdir().unwrap();
+        let error = prepare(
+            &settings("worktree"),
+            0,
+            "alpha",
+            "aaaaaaaa",
+            &plain.path().to_string_lossy(),
+            state.path(),
+            &[],
+        )
+        .unwrap_err();
+        let message = format!("{error:#}");
+        assert!(message.contains("git repository"), "{message}");
+        assert!(message.contains("isolation mode 'none'"), "{message}");
+    }
+}

--- a/src/omar.rs
+++ b/src/omar.rs
@@ -7,6 +7,7 @@ mod deploy;
 mod diagram;
 mod ea;
 mod event;
+mod isolation;
 mod manager;
 mod mcp;
 mod memory;
@@ -189,6 +190,11 @@ enum Commands {
         /// a wait.
         #[arg(long)]
         fast: bool,
+
+        /// How to separate this team from other teams: none, worktree, or
+        /// container. Overrides `[isolation] mode` for this run.
+        #[arg(long)]
+        isolation: Option<String>,
 
         /// Expose the live topology diagram API while the run is active
         #[arg(long)]
@@ -489,11 +495,19 @@ async fn async_main() -> Result<()> {
             replace,
             timeout_seconds,
             fast,
+            isolation,
             diagram_server,
             diagram_address,
         }) => {
             let target = resolve_cli_ea(&omar_dir, cli.ea.as_deref())?;
             let bytecode = topology::load_program(&program)?;
+            let mut isolation_config = config.isolation.clone();
+            if let Some(mode) = isolation {
+                // Reject an unknown mode here rather than after the run has
+                // already created a deployment record for it.
+                isolation::Mode::parse(&mode)?;
+                isolation_config.mode = mode;
+            }
             topology::run_topology(
                 &bytecode,
                 topology::TopologyRunConfig {
@@ -501,6 +515,7 @@ async fn async_main() -> Result<()> {
                     omar_dir: &omar_dir,
                     base_prefix: &config.dashboard.session_prefix,
                     default_workdir: &config.agent.default_workdir,
+                    isolation: &isolation_config,
                     health_idle_warning: config.health.idle_warning,
                     inputs: &inputs,
                     replace,

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -145,6 +145,9 @@ struct Context_ {
     ea_id: EaId,
     session_prefix: String,
     default_workdir: String,
+    /// Applies to deployed teams. The EA's own pane is not isolated: it
+    /// orchestrates teams rather than belonging to one.
+    isolation: crate::config::IsolationConfig,
     health_idle_warning: i64,
     runs: Runs,
     /// Where each run's web-backed invocations are answered. Absent for a run
@@ -239,6 +242,7 @@ impl Serve {
             ea_id,
             session_prefix: config.dashboard.session_prefix.clone(),
             default_workdir: config.agent.default_workdir.clone(),
+            isolation: config.isolation.clone(),
             health_idle_warning: config.health.idle_warning,
             runs: Runs::default(),
             panels: Panels::default(),
@@ -1369,6 +1373,7 @@ fn spawn_run_thread(
                 omar_dir: &context.omar_dir,
                 base_prefix: &context.session_prefix,
                 default_workdir: &context.default_workdir,
+                isolation: &context.isolation,
                 health_idle_warning: context.health_idle_warning,
                 inputs: &inputs,
                 replace,

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -17,6 +17,7 @@ use uuid::Uuid;
 use crate::config;
 use crate::deploy::{self, DeploymentState};
 use crate::diagram::{DiagramServer, NoopTopologyObserver, TopologyObserver};
+use crate::isolation;
 use crate::manager::{self, McpLaunchContext, TopologyMcpContext};
 use crate::tmux::flatten_agent_name;
 use crate::tmux::DeliveryOptions;
@@ -1336,7 +1337,11 @@ pub struct TopologyRunConfig<'a> {
     pub ea_id: crate::ea::EaId,
     pub omar_dir: &'a Path,
     pub base_prefix: &'a str,
+    /// The directory a run's workspace is derived from. Under `none` this is
+    /// where every agent launches; under the other modes it is the repository
+    /// each team's worktree is cut from.
     pub default_workdir: &'a str,
+    pub isolation: &'a crate::config::IsolationConfig,
     pub health_idle_warning: i64,
     pub inputs: &'a [String],
     pub replace: bool,
@@ -1479,6 +1484,27 @@ pub fn run_topology(bytecode: &Bytecode, config: TopologyRunConfig<'_>) -> Resul
     // Only what this run spawned. A failure must not tear down a session it
     // refused to replace.
     let mut spawned: BTreeMap<String, String> = BTreeMap::new();
+    let deployment_id = record
+        .lock()
+        .map_err(|_| anyhow::anyhow!("deployment record lock poisoned"))?
+        .deployment_id
+        .clone();
+    let workspace = match isolation::prepare(
+        config.isolation,
+        config.ea_id,
+        &state.team,
+        &deployment_id,
+        config.default_workdir,
+        &runtime_dir,
+        &launch_binaries(&state),
+    ) {
+        Ok(workspace) => workspace,
+        Err(error) => {
+            observer.run_failed(&error.to_string());
+            fail_deployment(&record, &runtime_dir, &client, &spawned, &error);
+            return Err(error);
+        }
+    };
     let prepared = (|| -> Result<(InvocationServer, BTreeMap<String, Value>)> {
         let invocation_server = InvocationServer::start()?;
         spawn_topology_agents(
@@ -1487,6 +1513,7 @@ pub fn run_topology(bytecode: &Bytecode, config: TopologyRunConfig<'_>) -> Resul
             &runtime_dir,
             &invocation_server,
             &config,
+            &workspace,
             &mut spawned,
         )?;
         let inputs = parse_inputs(&state, config.inputs)?;
@@ -1497,6 +1524,9 @@ pub fn run_topology(bytecode: &Bytecode, config: TopologyRunConfig<'_>) -> Resul
         Err(error) => {
             observer.run_failed(&error.to_string());
             fail_deployment(&record, &runtime_dir, &client, &spawned, &error);
+            // Keep the worktree: a run that failed during setup is exactly
+            // when an operator needs to see what the team was given.
+            report_workspace_failures(workspace.teardown(true));
             return Err(error);
         }
     };
@@ -1569,6 +1599,7 @@ pub fn run_topology(bytecode: &Bytecode, config: TopologyRunConfig<'_>) -> Resul
                 .map(|guard| guard.sessions.clone())
                 .unwrap_or_default();
             fail_deployment(&record, &runtime_dir, &executor.client, &sessions, &error);
+            report_workspace_failures(workspace.teardown(true));
             return Err(error);
         }
     };
@@ -1588,6 +1619,9 @@ pub fn run_topology(bytecode: &Bytecode, config: TopologyRunConfig<'_>) -> Resul
     {
         eprintln!("warning: session not cleaned up: {failure}");
     }
+    // After the panes, never before: a worktree cannot be removed while a
+    // pane still has it as a working directory.
+    report_workspace_failures(workspace.teardown(false));
     {
         let mut guard = record
             .lock()
@@ -1622,12 +1656,39 @@ pub fn run_topology(bytecode: &Bytecode, config: TopologyRunConfig<'_>) -> Resul
     })
 }
 
+/// Every distinct binary this run's panes will launch.
+///
+/// Container isolation has to prove the image carries them before a pane sits
+/// at "command not found" with nobody to read it. The launch command is the
+/// source of truth rather than the backend name, because a backend's binary
+/// and its name need not match — `cursor` launches `cursor agent`.
+fn launch_binaries(state: &VmState) -> Vec<String> {
+    state
+        .agents
+        .values()
+        .filter(|agent| !is_web_backend(&agent.backend))
+        .filter_map(|agent| config::resolve_backend(canonical_backend(&agent.backend)).ok())
+        .filter_map(|command| command.split_whitespace().next().map(str::to_string))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+/// Teardown is best effort: the run's own outcome is already decided, and a
+/// leftover container or worktree is an operator problem, not a run failure.
+fn report_workspace_failures(failures: Vec<String>) {
+    for failure in failures {
+        eprintln!("warning: workspace not cleaned up: {failure}");
+    }
+}
+
 fn spawn_topology_agents(
     state: &VmState,
     client: &TmuxClient,
     runtime_dir: &Path,
     invocation_server: &InvocationServer,
     config: &TopologyRunConfig<'_>,
+    workspace: &isolation::Workspace,
     spawned: &mut BTreeMap<String, String>,
 ) -> Result<()> {
     let protocol = "You are an OMAR topology agent. Only act on OMAR INVOCATION messages. You cannot message other agents. For each invocation, use only omar_set_port to set allowed effects and omar_complete to finish. Port writes are buffered and repeated writes use last-writer-wins semantics.";
@@ -1660,7 +1721,9 @@ fn spawn_topology_agents(
             ea_id: config.ea_id,
             session_prefix: config.base_prefix.to_string(),
             default_command: base_command.clone(),
-            default_workdir: config.default_workdir.to_string(),
+            // What this agent's own spawns inherit: its team's workspace, not
+            // the operator's checkout.
+            default_workdir: workspace.workdir().to_string(),
             health_idle_warning: config.health_idle_warning,
             tmux_server: std::env::var("OMAR_TMUX_SERVER").ok(),
             // Topology agents answer invocations; they do not chat with the
@@ -1674,7 +1737,8 @@ fn spawn_topology_agents(
             }),
         };
         let command = manager::build_agent_command(&base_command, &prompt_file, &[], &context);
-        client.new_session(&session, &command, Some(config.default_workdir))?;
+        let command = workspace.wrap_command(&command);
+        client.new_session(&session, &command, Some(workspace.workdir()))?;
         spawned.insert(name.clone(), session);
     }
 
@@ -2603,6 +2667,37 @@ mod tests {
         let loaded = load_program_with_compiler(&source_path, Some(&compiler_path)).unwrap();
 
         assert_eq!(loaded.team, "Demo");
+    }
+
+    #[test]
+    fn launch_binaries_are_what_a_container_image_must_carry() {
+        // Distinct, sorted, and named by the binary a pane actually runs —
+        // the container preflight probes these, so a backend whose binary and
+        // name differ must resolve to the binary.
+        let bytecode: Bytecode = serde_json::from_str(
+            r#"{
+              "version": 1,
+              "team": "Demo",
+              "instructions": [
+                {"op":"begin_plan","team":"Demo"},
+                {"op":"spawn_agent","name":"a","backend":"Codex"},
+                {"op":"spawn_agent","name":"b","backend":"Codex"},
+                {"op":"spawn_agent","name":"c","backend":"Cursor"},
+                {"op":"spawn_agent","name":"d","backend":"Web"},
+                {"op":"commit_plan"}
+              ]
+            }"#,
+        )
+        .unwrap();
+        let state = verify(&bytecode).unwrap();
+
+        let binaries = launch_binaries(&state);
+
+        // Two codex agents collapse to one probe; cursor launches `cursor
+        // agent`, so the binary is `cursor`, not the backend name.
+        assert_eq!(binaries, vec!["codex".to_string(), "cursor".to_string()]);
+        // A web agent has no pane and so nothing an image must carry.
+        assert!(!binaries.iter().any(|binary| binary == "web"));
     }
 
     #[test]


### PR DESCRIPTION
## Why

Every agent in a deployment launched in one shared directory (`config.default_workdir`, defaulting to `"."`), so teams could clobber each other's files and nothing separated one run from the next. Worse, `"."` is resolved by the *tmux server*, not by omar — on a long-lived server that is whatever directory the first session happened to be created from, so agents landed somewhere nobody chose.

The team is the natural unit of isolation: agents in a team share state on purpose, agents in different teams never should.

## What

`[isolation] mode` in config, or `omar run --isolation <mode>` per run.

| Mode | Each team gets | Needs |
|---|---|---|
| `none` (default) | nothing; previous behaviour | — |
| `worktree` | a git worktree, on its own branch | a git repo |
| `container` | that worktree, mounted in its own container | docker |

**worktree** — cut from `[agent] default_workdir`'s repository into the team's own state directory (`~/.omar/ea/<id>/topologies/<team>/worktree`), on branch `omar/<team>/<run>`. Removed when a run completes or is stopped; **kept** when a run fails or is cancelled, which is exactly when you need to see what the team did. The next deploy of the same team reclaims the path.

**container** — everything worktree does, plus a docker container per team. Panes run `docker exec` into it, so tmux, `omar list` and attach work unchanged. Host paths are mounted at their own absolute paths and `HOME` points at the host home, so the MCP config, system prompt and omar binary paths OMAR bakes into a launch command resolve identically inside. Mounts the worktree, `~/.omar`, the omar binary and every existing `credential_mounts` path.

The default image (`debian:bookworm-slim`) carries no agent CLIs, so container mode probes for each backend the team uses and refuses to deploy if one is missing, naming it and pointing at `docs/isolation.md` — otherwise every pane would sit at "command not found" with nobody reading it. `docs/agents.Dockerfile` is a worked example.

Teardown ordering matters and follows the existing one: panes die before the workspace, because a worktree cannot be removed while a pane still has it as a cwd.

## What this does not buy

Said plainly in the docs rather than left to be discovered:

- Worktree isolation separates working trees, not repositories. The object database is shared, so a team can read another team's branches.
- A team container shares credentials among its agents. It is a trust boundary, not a security one.
- The tmux server stays outside every container, so an agent that reaches OMAR's MCP surface can still ask for a pane on the host. This contains what an agent does in its own pane, not what it can ask OMAR for.
- opencode's loopback side channel does not survive container mode (the container has its own network namespace); delivery falls back to the pane. Other backends use unix sockets or files under mounted paths and are unaffected.

## Tests

13 new tests, all in CI, no docker required:

- Real-git worktree tests: two teams get separate checkouts of one repo, a write by one is invisible to the other, teardown unregisters rather than orphaning, a failed run keeps its worktree and the next run still reclaims the path, a non-repo source is refused with an actionable message.
- Container command wrapping preserves the quoting a backend already carries (codex's `-c model_reasoning_effort='"high"'`), verified against a real shell round-trip.
- A team name cannot inject a git or docker argument.
- Container names are stable per team so a container orphaned by a dead runner is reclaimed, and distinct across EAs.
- `launch_binaries` returns what an image must carry: deduplicated, and by binary rather than backend name (`cursor` launches `cursor agent`), with web agents excluded.

`cargo test --bin omar`: 402 passed. clippy and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHZy6vYYcMUm4rrJ2Q94x5
