### PR TITLE
Point the EA at the language spec, and make the spec worth pointing at

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,33 @@ jobs:
             lake exe omarc "$source" "/tmp/omar-topology-suite/$name.json"
           done
 
+      - name: Compile the spec's example programs
+        working-directory: lang
+        run: |
+          mkdir -p /tmp/omar-spec-examples
+          python3 - <<'PY'
+          import pathlib
+          import re
+
+          # A fenced `omar` block that opens with `team` is a whole program.
+          # The fragments elsewhere in the spec -- effect contracts, a lone
+          # timer -- are not, and are skipped.
+          text = pathlib.Path("spec.md").read_text(encoding="utf-8")
+          programs = [
+              block
+              for block in re.findall(r"```omar\n(.*?)```", text, re.S)
+              if block.lstrip().startswith("team")
+          ]
+          assert programs, "spec.md has no complete example programs to check"
+          out = pathlib.Path("/tmp/omar-spec-examples")
+          for index, program in enumerate(programs):
+              (out / f"spec{index}.omar").write_text(program, encoding="utf-8")
+          PY
+          for source in /tmp/omar-spec-examples/*.omar; do
+            echo "--- $source"
+            lake exe omarc "$source" "${source%.omar}.json"
+          done
+
       - name: Verify top-level OMAR source execution
         env:
           OMARC_BIN: ${{ github.workspace }}/lang/.lake/build/bin/omarc

--- a/lang/spec.md
+++ b/lang/spec.md
@@ -14,27 +14,41 @@ AI is used only inside prompt reactions, never for orchestration.
 ## 2. Syntax
 
 ```ebnf
-program     = "team", identifier, "(", agents, ")",
+program     = { team }, main ;
+
+team        = "team", identifier, [ "(", [ params ], ")" ],
+                                  [ "[", [ agents ], "]" ],
               "{", { declaration }, "}" ;
+params      = param, { ",", param } ;
+param       = identifier, ":", type ;
+agents      = agent, { ",", agent } ;
+agent       = identifier, ":", backend ;
+backend     = identifier ;
 
-agents      = [ agent, { ",", agent } ] ;
-agent       = identifier, ":", identifier ;
+main        = "main", [ identifier ], "{", { instance | wiring }, "}" ;
+wiring      = qualified, "->", qualified, [ "after", delay ] ;
 
-declaration = input | output | action | timer | connection | prompt ;
+declaration = input | output | action | timer | instance | connection
+            | prompt | ";" ;
 input       = "input", identifier, ":", type ;
 output      = "output", identifier, ":", type ;
 action      = "action", identifier, [ "(", "delay", "=", delay, ")" ],
               [ ":", type ] ;
 timer       = "timer", identifier, "(", delay, ",", delay, ")" ;
-connection  = identifier, "->", identifier, [ "after", delay ] ;
+instance    = identifier, "=", identifier, "(", [ args ], ")" ;
+args        = literal, { ",", literal } ;
+literal     = natural | string ;
+connection  = endpoint, "->", endpoint, [ "after", delay ] ;
+endpoint    = identifier | qualified ;
+qualified   = identifier, ".", identifier ;
 
-prompt      = "prompt", identifier, "(", triggers, ")",
-              "->", effects, [ deadline ], prompt-string ;
+prompt      = "prompt", identifier, "(", [ triggers ], ")",
+              "->", effects, [ deadline ], string ;
 deadline    = "within", "(", duration, ")" ;
 delay       = duration | "0" ;
 duration    = natural, unit ;
 unit        = "ns" | "us" | "ms" | "s" | "sec" | "min" | "h" | "hr" ;
-triggers    = [ identifier, { ",", identifier } ] ;
+triggers    = endpoint, { ",", endpoint } ;
 
 effects     = effect, { ",", effect } ;
 effect      = atom, [ "?" ]
@@ -50,7 +64,88 @@ natural     = digit, { digit } ;
 Identifiers are case-sensitive. `//` starts a line comment and `/* ... */`
 delimits a block comment.
 
-### 2.1 Declarations
+### 2.1 Teams, agents and main
+
+A team is a reusable unit. Its parameters go in `()`, its agents in `[]`, and
+both lists are optional — `team Name { ... }` is a team with neither.
+
+Declaring a team creates nothing; `main` instantiates. A program is the teams
+plus the `main` that uses them:
+
+```omar
+team Node(idx : int)[agent : Codex]
+{
+    input token : int
+    output out : int
+
+    prompt agent(token) -> out "You are node $(idx). Token: $(token)"
+}
+
+main Relay {
+    n1 = Node(1)
+    n2 = Node(2)
+
+    n1.out -> n2.token
+}
+```
+
+A parameter is read back in a prompt as `$(idx)`, the same spelling a trigger
+uses.
+
+An agent's backend names what answers its reactions: `Claude` (or
+`ClaudeCode`), `Codex`, `Cursor`, `OpenCode`, `Agy`, `Stub`, or `Web`. The
+compiler takes any identifier here; an unknown one compiles and fails when the
+runtime tries to start it. Case does not matter.
+
+An argument is an int or a string literal, and nothing else — there are no
+expressions. `main` may be named or bare; the name identifies the run, and a
+runtime allows only one run of a given name at a time. A program without a
+`main` does not compile.
+
+Wiring in `main` is `instance.port -> instance.port`. Both sides must be
+qualified, because in `main` there is nothing else for a bare name to mean.
+
+A team may also instantiate a team, so teams nest:
+
+```omar
+team Stage(role : string)[worker : Codex]
+{
+    input inp : string
+    output out : string
+
+    prompt worker(inp) -> out "You are the $(role) stage. Got $(inp)."
+}
+
+team Pipeline[reporter : Codex]
+{
+    input brief : string
+    output summary : string
+
+    draft = Stage("draft");
+    refine = Stage("refine");
+
+    brief -> draft.inp
+    draft.out -> refine.inp
+
+    prompt reporter(refine.out) -> summary "Report $(refine.out)."
+}
+
+main Nest {
+    run = Pipeline()
+}
+```
+
+Inside a team, what it instantiated is reached as `instance.port` — the same
+spelling `main` uses. A reaction may trigger on a contained instance's
+*output* (`reporter(refine.out)`), which is how a team observes what it
+contains; to send data the other way, connect to the contained input
+(`brief -> draft.inp`). A bare name is this team's own port. From outside,
+reach a nested port by its full path: `run.draft.out`.
+
+A `;` may separate declarations in a team body and means nothing else. It is
+not accepted in `main`.
+
+### 2.2 Declarations
 
 - `input` is a typed external entry point.
 - `output` is a typed externally observable result.
@@ -74,7 +169,7 @@ The prompt body is delivered to the agent. `$(name)` interpolates a trigger
 value and may only reference that prompt's triggers. If a declared trigger is
 not present in an invocation, its interpolation expands to `<absent>`.
 
-### 2.2 Effect contracts
+### 2.3 Effect contracts
 
 The expression after `->` declares the ports a reaction may set:
 
@@ -95,12 +190,12 @@ Every trigger must be an input or action. Every effect must be an output or
 action. A connection target must be an output or action, and its source and
 target types must match. Values must match their port types.
 
-### 2.3 Deadlines
+### 2.4 Deadlines
 
 `within(30s)` bounds how long one invocation may take, measured from when that
 invocation starts. Without it the run-wide timeout applies.
 
-See §2.4: a deadline is a duration like any other, and carries a unit.
+See §2.5: a deadline is a duration like any other, and carries a unit.
 
 What expiry does is read off the effect contract, so a deadline needs no
 second clause saying what to fall back to:
@@ -111,7 +206,7 @@ second clause saying what to fall back to:
 - a contract requiring an effect — `a`, `(a | b)` — has not been honoured.
   There is no value to invent, so the run fails.
 
-### 2.4 Durations
+### 2.5 Durations
 
 Every span of time in the language is a duration: `after`, a timer's offset and
 period, an action's `delay`, and `within`. All are stored as nanoseconds.
@@ -326,7 +421,7 @@ slow agent, and the runtime does not distinguish them:
 - it may write exactly its reaction's effects, because `omar_set_port` refuses
   anything else;
 - it is bound by `within` like any other reaction, and an expired deadline is
-  read off the contract as in §2.3.
+  read off the contract as in §2.4.
 
 An operator's decision is therefore recorded dataflow rather than a side effect
 on the run: it flows through the same completion path as a model's, so a run

--- a/lang/spec.md
+++ b/lang/spec.md
@@ -284,16 +284,12 @@ begin at `(0, 0)`. Every hop costs one of three things:
 This is Lingua Franca's rule: ports do not introduce delays. What a tag decides,
 it decides completely.
 
-<<<<<<< HEAD
 ### 4.0 Fixpoint at a tag
-=======
+
 A tag is a moment something is present at. One with no events is not reached:
 no reaction can be enabled there, and no connection, output or timer can move,
 so announcing it would report an advance that did not happen. A program admitted
 with no inputs and no timer therefore passes through no tags at all.
-
-At each tag, the runtime:
->>>>>>> 26214fc (Do not announce a tag nothing is present at)
 
 A reaction fires at most once per tag, and only once the presence of every one
 of its triggers is decided. Ordering is not something a program asks for; it

--- a/prompts/executive-assistant.md
+++ b/prompts/executive-assistant.md
@@ -119,6 +119,20 @@ Always name the main block, as `Relay` is named above. That name identifies the
 run in Mission Control, and the runtime lets only one run of a given name go at
 a time, so two designs sharing a name cannot run together.
 
+What is above is a summary of the parts a design usually needs. The full
+language reference — the grammar, every port type, effect contracts, deadlines
+and durations — is one file, and you can read it:
+
+https://raw.githubusercontent.com/omar-os/omar/main/lang/spec.md
+
+Fetch it before proposing anything the summary does not cover: types beyond
+`int` and `string`, optional or alternative effects (`log?`, `(a | b)`),
+`within(...)` deadlines, `after` delays on connections, or `action` ports. It
+is the same spec the compiler implements, so it settles what compiles.
+
+If you cannot reach the network, propose from the summary above and say which
+part you were unsure of rather than guessing at syntax.
+
 Think out loud. Drafting takes time and the operator sees only a spinner until
 you say something, so send `omar_reply` with `progress: true` as you go:
 

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -1908,6 +1908,28 @@ mod tests {
         }
     }
 
+    /// The EA is told where the language reference is, and it is there.
+    ///
+    /// The prompt teaches a summary of the language and points past it at
+    /// `lang/spec.md` on GitHub, because the summary does not cover the whole
+    /// language and a proposal that misses is a compile error the operator
+    /// waits through. Moving or renaming the spec would leave the EA fetching
+    /// a 404 -- silently, since nothing else in the tree reads this URL.
+    #[test]
+    fn the_ea_is_pointed_at_a_language_spec_that_is_there() {
+        const RAW: &str = "https://raw.githubusercontent.com/omar-os/omar/main/";
+        let url = PROMPT_EA
+            .split_whitespace()
+            .find(|word| word.starts_with(RAW))
+            .expect("the EA prompt names the language spec");
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(url.trim_start_matches(RAW));
+        assert!(
+            path.exists(),
+            "the EA prompt points at {url}, which is not {}",
+            path.display()
+        );
+    }
+
     #[test]
     fn embedded_prompts_forbid_backend_native_wake_tools() {
         for prompt in [PROMPT_EA, PROMPT_AGENT] {


### PR DESCRIPTION
The EA drafts OMAR programs from what its prompt teaches, and its prompt teaches a summary — teams, agents, timers, nesting, `main`. Nothing in it mentions `lang/spec.md`. Everything the summary leaves out is something the EA has to guess at: port types beyond `int` and `string`, `log?` and `(a | b)` contracts, `within(...)`, `after`, `action` ports. A guess that misses is a compile error the operator waits through.

The prompt now names the spec, as a URL rather than a file. Prompts are `include_str!`'d into the binary and written to `~/.omar/prompts/`, so an installed `omar` has no checkout to read a relative path out of. The repo is public, so a link works from anywhere the EA runs:

```
https://raw.githubusercontent.com/omar-os/omar/main/lang/spec.md
```

The summary stays. It is what a design usually needs, and the EA should not have to fetch anything for the common case — or when it has no network, which the prompt now says what to do about.

## The spec could not be pointed at as it stood

§2's grammar had drifted from the compiler on exactly the constructs the EA needs most:

| | `lang/spec.md` §2 | `lang/Omar/Compiler.lean` |
|---|---|---|
| team agents | `(a : Codex)` | `[a : Codex]` |
| team parameters | — | `(idx : int)` |
| instances | — | `n1 = Node(1)` |
| `main` | — | required (`expectWord "main"`) |

Pointing the EA at that would have handed it a grammar the compiler rejects, contradicting the working examples already in its own prompt — worse than not pointing at all.

So §2's EBNF is rewritten against the parser, and a new **§2.1 Teams, agents and main** covers the half that was missing rather than merely wrong: parameter and agent lists, backends, instantiation, argument literals, `main`'s stricter wiring. §2.2–2.5 (declarations, effect contracts, deadlines, durations) were accurate, are the material the prompt most lacks, and are untouched beyond renumbering.

Every claim in §2.1 was put to `omarc` rather than read off the parser:

| claim | checked |
|---|---|
| a team with neither list compiles | ✓ |
| an unnamed `main` compiles | ✓ |
| an unknown backend compiles, and fails at spawn | ✓ |
| `;` in `main` is rejected | ✓ `unexpected token in main` |
| an unqualified endpoint in `main` is rejected | ✓ `expected '.', found '}'` |

## Tests

**`the_ea_is_pointed_at_a_language_spec_that_is_there`** reads the URL back out of the prompt and checks the repo path it names exists. Moving or renaming the spec would otherwise leave the EA fetching a 404 — silently, because nothing else in the tree reads this URL. Verified it fails on a renamed spec.

**A new `OMAR Language` step** compiles every fenced `omar` block in the spec that opens with `team`. That is precisely the property that broke here: the spec's examples have to be programs. The fragments elsewhere in the spec (effect contracts, a lone timer) do not open with `team` and are skipped. Verified it fails when the first example is regressed to the old grammar:

```
/tmp/omar-spec-examples/spec0.omar: unknown port type 'Codex'
omarc exit=1
```

It lives in CI rather than in `cargo test` because compiling needs `omarc`, and that job is the one with a Lean toolchain — the same bargain the topology-corpus step above it already makes.

394 Rust, Lean `lake test`, both spec examples compile; `cargo fmt` and clippy clean.

One pre-existing failure: `scheduler::tests::event_loop_keeps_deferring_while_popup_stays_open` reproduces on a clean checkout of `origin/main` (393 passing there against 394 here, the difference being the test this PR adds) and passes when run alone. It is an 80ms tokio race, unrelated.

## Also fixed

`lang/spec.md` still had an unresolved merge conflict in it — `<<<<<<<`, `=======`, `>>>>>>>` around the section on tags. It came in with `fa87dcc` (#195) and has been sitting on `main` ever since; this PR only shifted it down the file. Fixing it here rather than separately because this PR's whole premise is pointing the EA at this document, and the EA would have been fetching conflict markers as reference material.

Both sides carried real content, so it was not a delete. The `HEAD` side had rewritten the section and named it `### 4.0 Fixpoint at a tag` — the heading stays. The other side's lead-in `At each tag, the runtime:` introduced a seven-step list that the rewrite had already replaced with its own five-step one, leaving the line dangling with nothing under it — that goes. Its paragraph on a tag with no events being unreachable is the substance of `26214fc` and is stated nowhere else, so it stays, now under the heading.

Note this does not reach the EA until it lands on `main`: `prompts/executive-assistant.md` fetches the spec from the `main` branch by raw URL.

## Not done here

`prompts/agent.md` — what a spawned worker is told — is not touched. Workers do not draft programs, so the spec is not theirs to read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXfv5Gf7WTfeAXM32VxscV

