### PR TITLE
Keep assistant terminal access available after a topology opens

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -63,6 +63,19 @@ button {
   backdrop-filter: blur(16px);
 }
 
+.terminal-button {
+  padding: 7px 10px;
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.terminal-button:hover:not(:disabled) { border-color: var(--purple); }
+.terminal-button:disabled { opacity: 0.5; cursor: default; }
+
 .brand,
 .runtime-controls,
 .runtime-controls label,
@@ -1541,8 +1554,14 @@ h2 {
   .topbar {
     height: auto;
     align-items: flex-start;
+    flex-wrap: wrap;
     gap: 12px;
     padding: 12px;
+  }
+
+  .runtime-controls {
+    flex-wrap: wrap;
+    max-width: 100%;
   }
 
   .runtime-controls label {

--- a/web/app/studio.tsx
+++ b/web/app/studio.tsx
@@ -628,7 +628,7 @@ export function Studio({
           {!isDemo ? (
             <button
               type="button"
-              className="waiting-inspect"
+              className="terminal-button"
               onClick={() => setTerminalAgent(ASSISTANT)}
               disabled={daemon.state !== "live"}
               aria-haspopup="dialog"

--- a/web/app/studio.tsx
+++ b/web/app/studio.tsx
@@ -625,6 +625,17 @@ export function Studio({
           <span>OMAR <b>Mission Control</b></span>
         </div>
         <div className="runtime-controls">
+          {!isDemo ? (
+            <button
+              type="button"
+              className="waiting-inspect"
+              onClick={() => setTerminalAgent(ASSISTANT)}
+              disabled={daemon.state !== "live"}
+              aria-haspopup="dialog"
+            >
+              Inspect on terminal
+            </button>
+          ) : null}
           <span
             className={`daemon ${daemon.state}`}
             aria-label="Runtime mode"
@@ -673,24 +684,7 @@ export function Studio({
             {messages.map((message) => (
               <ChatMessageView key={message.sequence} message={message} />
             ))}
-            {phase === "drafting" ? (
-              // The assistant is not on the diagram, so the double click that
-              // opens an agent's terminal cannot reach it. Offered beside the
-              // wait it belongs to, rather than inside a menu that has to be
-              // opened first.
-              <div className="waiting-row">
-                <Waiting />
-                {daemon.state === "live" ? (
-                  <button
-                    type="button"
-                    className="waiting-inspect"
-                    onClick={() => setTerminalAgent(ASSISTANT)}
-                  >
-                    Inspect on terminal
-                  </button>
-                ) : null}
-              </div>
-            ) : null}
+            {phase === "drafting" ? <Waiting /> : null}
             {phase === "spawning" ? <Waiting label="Starting the run" /> : null}
           </div>
 

--- a/web/tests/e2e/flow.spec.ts
+++ b/web/tests/e2e/flow.spec.ts
@@ -1353,40 +1353,32 @@ test("the diagram follows the text", async ({ page }) => {
   await expect(stats).not.toContainText("ready");
 });
 
-test("the assistant's terminal opens from the wait, not from a menu", async ({
-  page,
-}) => {
-  // The assistant is not on the diagram, so the gesture that opens an agent's
-  // terminal cannot reach it. It is offered beside the wait it belongs to: the
-  // moment there is something to look at is the moment it is drafting.
-  await fake.close();
-  fake = (await startFakeServe({ stepMs: 3000, port: FAKE_SERVE_PORT })) as FakeServe;
+test("the assistant terminal remains available before and after a topology opens", async ({ page }) => {
   await useFakeServe(page);
-
-  // Nothing is drafting yet, so there is nothing to inspect.
-  await expect(page.getByRole("button", { name: "Inspect on terminal" })).toBeHidden();
-
-  await page.getByLabel("Describe a workflow").fill("Review the release plan");
-  await page.keyboard.press("Enter");
-
   const inspect = page.getByRole("button", { name: "Inspect on terminal" });
-  await expect(inspect).toBeVisible();
-  // Beside the wait rather than under anything: one click, nothing to open.
-  const waitBox = (await page.locator(".waiting").boundingBox())!;
-  const inspectBox = (await inspect.boundingBox())!;
-  expect(inspectBox.x).toBeGreaterThanOrEqual(waitBox.x + waitBox.width - 1);
+  await expect(inspect).toBeEnabled();
   await inspect.click();
-
-  const terminal = page.getByRole("dialog");
-  await expect(terminal).toBeVisible();
+  const terminal = page.getByRole("dialog", { name: "Terminal for the assistant" });
   await expect(terminal).toContainText(/\d+×\d+ · attached/);
-  // Named as itself, not as an agent.
   await expect(terminal.locator("h2")).toHaveText("assistant");
-  // And said plainly: the chat drives this same pane.
   await expect(terminal).toContainText("same session the chat talks to");
-
   await page.getByRole("button", { name: "Close terminal" }).click();
-  await expect(terminal).toBeHidden();
+
+  await draftUntilProposed(page);
+  await expect(inspect).toBeEnabled();
+  await inspect.click();
+  await expect(terminal).toBeVisible();
+  await page.getByRole("button", { name: "Close terminal" }).click();
+  await expect(page.getByRole("group", { name: "Deploy design" })).toBeVisible();
+  await expect(page.locator(".messages")).toContainText("The planner");
+
+  // The topbar remains reachable even when the conversation is collapsed.
+  await dragDivider(page, "Resize the conversation", -2000);
+  await expect(inspect).toBeVisible();
+  await deploy(page);
+  await expect(page.locator(".connection")).toContainText("finished", { timeout: 30_000 });
+  await inspect.click();
+  await expect(terminal).toBeVisible();
 });
 
 test("dragging the canvas does not select the diagram", async ({ page }) => {

--- a/web/tests/e2e/flow.spec.ts
+++ b/web/tests/e2e/flow.spec.ts
@@ -1377,6 +1377,10 @@ test("the assistant terminal remains available before and after a topology opens
   await expect(inspect).toBeVisible();
   await deploy(page);
   await expect(page.locator(".connection")).toContainText("finished", { timeout: 30_000 });
+  await page.setViewportSize({ width: 390, height: 844 });
+  const bounds = (await inspect.boundingBox())!;
+  expect(bounds.x).toBeGreaterThanOrEqual(0);
+  expect(bounds.x + bounds.width).toBeLessThanOrEqual(390);
   await inspect.click();
   await expect(terminal).toBeVisible();
 });


### PR DESCRIPTION
The assistant’s **Inspect on terminal** button currently appears only while drafting. Once a topology proposal arrives, it disappears, preventing operators from inspecting terminal output or handling approvals.

Move the control into the persistent Mission Control top bar with a clear button style. It remains available before a proposal, during review and execution, after completion, and when the conversation pane is collapsed. Opening and closing the terminal preserves the chat and topology. The toolbar wraps on narrow screens so the control remains reachable. It is disabled while the runtime is unreachable and omitted in demo mode.

Validation:
- Production frontend build and ESLint pass.
- Updated Playwright regression passes against the built application, covering initial terminal access, topology review, preserved chat, collapsed conversation, and completed execution.
- Desktop and 390px viewport checks confirm the control remains visible and opens the terminal.
- Independent merge with saved chat history (#245) is clean; combined feature regressions pass.
- The standalone TypeScript check reports only the existing missing Cloudflare `Fetcher`/`D1Database` globals in unchanged `worker/index.ts`.

Agent execution and deployment confirmation retain their existing behavior.