### PR TITLE
Add agent activity and progress visibility to Omar’s web UI

### DIFF
--- a/docs/agent-activity.md
+++ b/docs/agent-activity.md
@@ -1,0 +1,101 @@
+# Agent activity in the web UI
+
+Inspect an agent from the topology's **Inspect agent** picker or the selected
+reaction's **View activity** action. Nodes show task/role, runtime state and
+invocation elapsed time. The panel contains current tools, latest activity,
+recent events, attributable file changes and diffs. A successful file edit is
+**changed**, not **verified**. Command exit codes are check evidence; Omar does
+not infer that they verify every file.
+
+## Sources and compatibility
+
+- Every `omar serve` workflow backend: runtime invocation start/end and elapsed
+  time, recorded independently for concurrent agents. Activity does not wait for
+  committed outputs or the rest of the execution layer.
+- Codex per-pane app-server: `thread/loaded/list` must identify exactly one thread.
+  `thread/read` hydrates history; `thread/resume` subscribes without configuration
+  overrides. Allowlisted item starts/completions produce concise tool categories,
+  errors and scoped file-edit patches. Neither terminal scraping nor elapsed time
+  is used to infer tool execution.
+- Backend turns are attributed by the delivered `invocation_id` user-message
+  marker or the `turn/start` response. Bootstrap/manual turns are not attributed
+  merely because their timestamps are close. Known IDs deduplicate replay;
+  completed invocations reject late updates.
+- Some Codex versions/new threads refuse history or resume before materializing a
+  user message. Metadata-only reads retain configuration access; detailed activity
+  is explicitly unavailable and retried. Ambiguous or changed threads fail closed.
+- Other backends: runtime timing plus **Activity details unavailable** and terminal
+  access. No inferred reasoning, tool execution, model/effort, or file attribution.
+
+Unix milliseconds come from Omar for runtime lifecycle/observation and from the
+backend when item lifecycle timestamps exist. Recovered history without timestamps
+is labeled as recovered/observed; it does not invent tool starts. The browser clock
+is anchored to server time. A long-running open tool suppresses the inactivity
+notice; a disconnect is shown separately. The default notice is two minutes,
+configurable from 30 seconds to one hour; it never interrupts execution.
+
+## Model and effort
+
+**Role model and effort settings** uses live `model/list` capabilities. Only Codex
+choices returned by a connected pane are offered; refresh retries discovery.
+Requested choices persist in the daemon's EA-scoped `role-settings-<id>.json`.
+Each invocation snapshots its requested settings at start. With an explicit model,
+Omar validates that pane's current catalog and submits `turn/start` with that model
+and the requested/catalog-default effort, without changing approval policy. A
+missing/ambiguous connection or rejected request fails explicitly, never silently
+restarting or retrying a potentially accepted turn through the terminal.
+
+**Keep backend configuration** means no override; it does not reset sticky backend
+settings. Mid-run changes apply to the next invocation. The accepted request,
+reported thread configuration, and confirmed execution settings are separate.
+The current adapter does not have per-turn execution confirmation: confirmed model
+and effort say **Not reported** even if a request was accepted or thread settings
+were reported. Account/provider rejection remains a backend error.
+
+## Artifacts, privacy and retention
+
+Only successful `fileChange` items identify attributable created/modified/deleted
+files. Diffs come from that tool item, never a shared-workspace watcher. Shell/MCP
+edits without a structured file-change item may be missing. Paths outside the
+workspace, traversal, symlinks, hidden/credential files are omitted. Raw tool
+arguments, commands, output, reasoning and user-input requests are not exposed.
+Sensitive patch lines/key blocks are redacted. Each diff is capped at 16 KiB;
+truncation is explicit. This filtering intentionally favors omitted detail.
+
+`GET /v1/runs/<run_id>/activity` returns a sequenced snapshot, polled once per second.
+The daemon retains 100 recent invocations (all active ones retained), 200 recent
+events and 30 recent artifacts per invocation. Reload/reconnect fetches the same
+IDs and timestamps. The browser retains only the selected run and topology without
+port values in session storage; activity is fetched afresh. Activity is in memory
+for the daemon lifetime, including after run completion. Daemon restart/history
+archival and restoration in a different browser are not implemented here.
+
+`GET/POST /v1/role-settings` read/save requested role settings; saving never mutates
+an active response. Rust owns these wire types; regenerate using
+`UPDATE_PROTOCOL=1 cargo test --bin omar protocol`, then rerun without that variable.
+
+## Separate approval source
+
+Pending approvals belong to the independent [approval PR #246](https://github.com/omar-os/omar/pull/246): `/v1/approvals` and
+`/v1/approvals/events`, with snapshot `sequence`, `requests`, `monitors`, `recent`.
+Match `run_id` + `invocation_id` and `agent_id` (`agent::<qualified-name>`).
+That source owns the orange waiting state, request links and approval counts.
+Its connectivity must not replace execution/activity connectivity. This PR does
+not infer approvals, add a response button, or include the terminal/history PRs
+#244 and #245. When combining changes, retain both independent optional
+`TopologyRunConfig` and `DiagramCanvas` props and regenerate protocol types.
+
+## Verification
+
+- Real runtime: Rust invocation-registry concurrency test and model-free daemon
+  conformance with real stub-agent invocations; timing survives diagram shutdown.
+- Real installed Codex 0.153.4, isolated empty app-server: Unix WebSocket handshake,
+  `model/list` and metadata reads. Empty legacy/new-format history refusal confirmed.
+  No model invocation or live user agent was used for this smoke check.
+- Explicit fixtures: Unix-socket JSON-RPC settings/capability refusal; safe activity
+  projection, duplicates, delayed events, privacy, recovery and independent agents.
+  Playwright covers two concurrent agents, a long tool, inactivity threshold,
+  request/active-setting separation, diffs, disconnect/reconnect, reload and
+  completion at desktop and mobile sizes. Other backends' detailed telemetry and
+  a live model-driven file edit remain unverified; approval lifecycle is tested by
+  its separate PR.

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -1,0 +1,1304 @@
+//! Evidence-only invocation telemetry. No terminal scraping, reasoning, tool
+//! arguments, command output, or filesystem-wide attribution enters this API.
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Component, Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use ts_rs::TS;
+
+use crate::channel::CodexSession;
+use crate::tmux::TmuxClient;
+
+pub fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ActivityExecution {
+    Running,
+    Completed,
+    Failed,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, TS, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ActivityConnection {
+    Connecting,
+    Connected,
+    Disconnected,
+    Unsupported,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+pub struct ActivityEvent {
+    pub id: String,
+    pub at: u64,
+    // Backend lifecycle timestamp when present; otherwise server observation time.
+    pub time_source: String,
+    pub kind: String,
+    pub summary: String,
+    pub tool_id: Option<String>,
+    pub exit_code: Option<i64>,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+pub struct ObservedTool {
+    pub id: String,
+    pub summary: String,
+    pub started_at: Option<u64>,
+    pub observed_at: u64,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+pub struct ChangedArtifact {
+    pub id: String,
+    pub path: String,
+    pub change: String,
+    pub observed_at: u64,
+    // A bounded, redacted patch from this agent's successful file-change item.
+    pub diff: Option<String>,
+    pub diff_truncated: bool,
+    pub verification: String,
+}
+#[derive(Debug, Clone, Default, Serialize, Deserialize, TS, PartialEq, Eq)]
+pub struct RoleSelection {
+    pub model: Option<String>,
+    pub effort: Option<String>,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+pub struct InvocationActivity {
+    pub invocation_id: String,
+    pub reaction_id: String,
+    pub agent_name: String,
+    pub backend: String,
+    pub started_at: u64,
+    pub finished_at: Option<u64>,
+    pub execution: ActivityExecution,
+    pub connection: ActivityConnection,
+    pub last_activity_at: u64,
+    pub events: Vec<ActivityEvent>,
+    pub active_tools: Vec<ObservedTool>,
+    pub artifacts: Vec<ChangedArtifact>,
+    pub requested: RoleSelection,
+    // Only per-invocation backend execution telemetry can confirm these.
+    pub confirmed: RoleSelection,
+    // thread/read reports configuration, not per-turn execution telemetry.
+    pub reported_thread_settings: RoleSelection,
+    pub settings_application: String,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+pub struct ActivitySnapshot {
+    pub run_id: String,
+    pub sequence: u64,
+    pub server_time: u64,
+    pub invocations: Vec<InvocationActivity>,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+pub struct SupportedModel {
+    pub model: String,
+    pub name: String,
+    pub efforts: Vec<String>,
+    pub default_effort: Option<String>,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+pub struct SavedRoleSettings {
+    pub team: String,
+    pub agent: String,
+    pub backend: String,
+    pub selection: RoleSelection,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+pub struct RoleSettingsSnapshot {
+    pub roles: Vec<SavedRoleSettings>,
+    pub codex_models: Vec<SupportedModel>,
+    pub capabilities_available: bool,
+}
+
+#[derive(Clone)]
+pub struct RoleSettings {
+    roles: Arc<Mutex<Vec<SavedRoleSettings>>>,
+    path: PathBuf,
+}
+impl RoleSettings {
+    pub fn load(path: PathBuf) -> Self {
+        let roles = std::fs::read(&path)
+            .ok()
+            .and_then(|v| serde_json::from_slice(&v).ok())
+            .unwrap_or_default();
+        Self {
+            roles: Arc::new(Mutex::new(roles)),
+            path,
+        }
+    }
+    pub fn all(&self) -> Vec<SavedRoleSettings> {
+        self.roles.lock().expect("role settings poisoned").clone()
+    }
+    pub fn requested(&self, team: &str, agent: &str, backend: &str) -> RoleSelection {
+        self.all()
+            .into_iter()
+            .find(|r| r.team == team && r.agent == agent && r.backend == backend)
+            .map(|r| r.selection)
+            .unwrap_or_default()
+    }
+    pub fn save(&self, role: SavedRoleSettings, models: &[SupportedModel]) -> Result<()> {
+        anyhow::ensure!(
+            !role.team.is_empty()
+                && role.team.len() <= 256
+                && !role.agent.is_empty()
+                && role.agent.len() <= 256,
+            "invalid role identity"
+        );
+        anyhow::ensure!(
+            role.backend == "codex",
+            "this backend does not support model settings through Omar"
+        );
+        validate_selection(&role.selection, models)?;
+        let mut roles = self.roles.lock().expect("role settings poisoned");
+        let mut next = roles.clone();
+        next.retain(|r| {
+            !(r.team == role.team && r.agent == role.agent && r.backend == role.backend)
+        });
+        next.push(role);
+        write_private_json(&self.path, &next)?;
+        *roles = next;
+        Ok(())
+    }
+}
+fn write_private_json(path: &Path, value: &impl Serialize) -> Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+    std::fs::create_dir_all(path.parent().context("missing parent")?)?;
+    let tmp = path.with_extension(format!("{}.tmp", uuid::Uuid::new_v4()));
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&tmp)?;
+    file.write_all(&serde_json::to_vec(value)?)?;
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}
+fn validate_selection(selection: &RoleSelection, models: &[SupportedModel]) -> Result<()> {
+    let Some(model) = &selection.model else {
+        anyhow::ensure!(
+            selection.effort.is_none(),
+            "select a model before an effort"
+        );
+        return Ok(());
+    };
+    let supported = models
+        .iter()
+        .find(|m| &m.model == model)
+        .context("model is not currently supported")?;
+    if let Some(effort) = &selection.effort {
+        anyhow::ensure!(
+            supported.efforts.contains(effort),
+            "effort is not supported by this model"
+        );
+    }
+    Ok(())
+}
+pub fn supported_models(session: &mut CodexSession) -> Result<Vec<SupportedModel>> {
+    let mut result = Vec::new();
+    let mut cursor = Value::Null;
+    // Bound a misbehaving/paginating server; never present a partial catalog.
+    for _ in 0..20 {
+        let page = session.call("model/list", json!({"cursor": cursor, "limit": 100}))?;
+        for model in page["data"].as_array().context("missing model catalog")? {
+            if model["hidden"].as_bool() == Some(true) {
+                continue;
+            }
+            let Some(id) = model["model"].as_str().filter(|s| safe_identifier(s)) else {
+                continue;
+            };
+            let efforts = model["supportedReasoningEfforts"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .filter_map(|e| e["reasoningEffort"].as_str())
+                .filter(|s| safe_identifier(s))
+                .map(str::to_string)
+                .collect();
+            result.push(SupportedModel {
+                model: id.into(),
+                name: id.into(),
+                efforts,
+                default_effort: model["defaultReasoningEffort"]
+                    .as_str()
+                    .filter(|s| safe_identifier(s))
+                    .map(str::to_string),
+            });
+        }
+        cursor = page["nextCursor"].clone();
+        if cursor.is_null() {
+            return Ok(result);
+        }
+    }
+    bail!("model catalog pagination did not finish")
+}
+pub fn codex_socket(client: &TmuxClient, agent: &str) -> Option<PathBuf> {
+    client
+        .session_delivery(&client.session_for(agent))?
+        .strip_prefix("codex:")
+        .map(PathBuf::from)
+}
+pub fn models_from_socket(path: &Path) -> Result<Vec<SupportedModel>> {
+    supported_models(&mut CodexSession::open(path)?)
+}
+
+#[derive(Clone)]
+pub struct ActivityRun {
+    snapshot: Arc<Mutex<ActivitySnapshot>>,
+    pub settings: RoleSettings,
+    pub team: String,
+    pub backends: BTreeMap<String, String>,
+    pub workdir: PathBuf,
+}
+impl ActivityRun {
+    pub fn new(
+        run_id: String,
+        team: String,
+        backends: BTreeMap<String, String>,
+        settings: RoleSettings,
+        workdir: PathBuf,
+    ) -> Self {
+        Self {
+            snapshot: Arc::new(Mutex::new(ActivitySnapshot {
+                run_id,
+                sequence: 0,
+                server_time: now_ms(),
+                invocations: Vec::new(),
+            })),
+            settings,
+            team,
+            backends,
+            workdir,
+        }
+    }
+    pub fn snapshot(&self) -> ActivitySnapshot {
+        let mut snapshot = self.snapshot.lock().expect("activity poisoned").clone();
+        snapshot.server_time = now_ms();
+        snapshot
+    }
+    pub fn start(&self, id: &str, reaction: &str, agent: &str) {
+        let mut snapshot = self.snapshot.lock().expect("activity poisoned");
+        if snapshot.invocations.iter().any(|i| i.invocation_id == id) {
+            return;
+        }
+        let at = now_ms();
+        let backend = self.backends.get(agent).cloned().unwrap_or_default();
+        let requested = self.settings.requested(&self.team, agent, &backend);
+        snapshot.invocations.push(InvocationActivity {
+            invocation_id: id.into(), reaction_id: reaction.into(), agent_name: agent.into(),
+            connection: if backend == "codex" { ActivityConnection::Connecting } else { ActivityConnection::Unsupported },
+            backend, started_at: at, finished_at: None, execution: ActivityExecution::Running,
+            last_activity_at: at, events: vec![ActivityEvent { id: format!("{id}:start"), at,
+                time_source: "runtime".into(), kind: "invocation_started".into(), summary: "Invocation started".into(), tool_id: None, exit_code: None }],
+            active_tools: Vec::new(), artifacts: Vec::new(), requested,
+            confirmed: RoleSelection::default(), reported_thread_settings: RoleSelection::default(), settings_application: "No override; keeps current backend configuration; active execution settings not reported".into(),
+        });
+        // Bounded replay, preserving running invocations even for large teams.
+        if snapshot.invocations.len() > 100 {
+            if let Some(index) = snapshot
+                .invocations
+                .iter()
+                .position(|i| i.finished_at.is_some())
+            {
+                snapshot.invocations.remove(index);
+            }
+        }
+        snapshot.sequence += 1;
+    }
+    fn update(&self, id: &str, f: impl FnOnce(&mut InvocationActivity)) {
+        let mut snapshot = self.snapshot.lock().expect("activity poisoned");
+        let Some(invocation) = snapshot
+            .invocations
+            .iter_mut()
+            .find(|i| i.invocation_id == id)
+        else {
+            return;
+        };
+        // Late events must never reopen an invocation, overwrite its outcome,
+        // or attach another invocation's artifacts to it.
+        if invocation.finished_at.is_some() {
+            return;
+        }
+        f(invocation);
+        snapshot.sequence += 1;
+    }
+    pub fn finish(&self, id: &str, success: bool, effects: usize) {
+        self.finish_at(id, success, effects, now_ms());
+    }
+    pub fn finish_at(&self, id: &str, success: bool, effects: usize, at: u64) {
+        self.update(id, |i| {
+            i.execution = if success { ActivityExecution::Completed } else { ActivityExecution::Failed };
+            i.finished_at = Some(at);
+            i.active_tools.clear();
+            event(i, ActivityEvent { id: format!("{id}:end"), at, time_source: "runtime".into(),
+                kind: "invocation_ended".into(), summary: if success { format!("Invocation completed · {effects} workflow effects; file verification is separate") } else { "Invocation failed · inspect the agent terminal".into() }, tool_id: None, exit_code: None });
+        });
+    }
+    pub fn connection(&self, id: &str, state: ActivityConnection) {
+        self.update(id, |i| i.connection = state);
+    }
+    pub fn active(&self, id: &str) -> bool {
+        self.snapshot
+            .lock()
+            .expect("activity poisoned")
+            .invocations
+            .iter()
+            .any(|i| i.invocation_id == id && i.finished_at.is_none())
+    }
+    pub fn requested(&self, id: &str) -> RoleSelection {
+        self.snapshot()
+            .invocations
+            .into_iter()
+            .find(|i| i.invocation_id == id)
+            .map(|i| i.requested)
+            .unwrap_or_default()
+    }
+    pub fn application(&self, id: &str, text: &str) {
+        self.update(id, |i| i.settings_application = text.into());
+    }
+}
+fn event(i: &mut InvocationActivity, e: ActivityEvent) {
+    if i.events.iter().any(|old| old.id == e.id) {
+        return;
+    }
+    i.last_activity_at = i.last_activity_at.max(e.at);
+    i.events.push(e);
+    i.events
+        .sort_by(|a, b| a.at.cmp(&b.at).then(a.id.cmp(&b.id)));
+    if i.events.len() > 200 {
+        i.events.remove(0);
+    }
+}
+fn safe_identifier(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 100
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || "_-/.:".contains(c))
+}
+fn tool_summary(item: &Value) -> Option<String> {
+    match item["type"].as_str()? {
+        "commandExecution" => {
+            // Display categories, never command text, shell assignments or args.
+            let read = item["commandActions"]
+                .as_array()
+                .is_some_and(|a| !a.is_empty() && a.iter().all(|a| a["type"] == "read"));
+            Some(
+                if read {
+                    "Reading files"
+                } else {
+                    "Running command"
+                }
+                .into(),
+            )
+        }
+        "fileChange" => Some("Editing files".into()),
+        "mcpToolCall" => Some(
+            item["tool"]
+                .as_str()
+                .filter(|s| safe_identifier(s))
+                .map(|s| format!("Tool: {s}"))
+                .unwrap_or_else(|| "Running tool".into()),
+        ),
+        "webSearch" => Some("Searching the web".into()),
+        "dynamicToolCall" => Some("Running tool".into()),
+        _ => None,
+    }
+}
+fn scoped_path(path: &str, root: &Path) -> Option<String> {
+    let path = Path::new(path);
+    let relative = if path.is_absolute() {
+        path.strip_prefix(root).ok()?
+    } else {
+        path
+    };
+    if relative
+        .components()
+        .any(|c| !matches!(c, Component::Normal(_)))
+    {
+        return None;
+    }
+    // A lexically in-workspace path can traverse a symlink into credentials
+    // elsewhere. File contents are never read; conservatively omit symlinks.
+    let mut checked = root.to_path_buf();
+    for component in relative.components() {
+        checked.push(component);
+        if std::fs::symlink_metadata(&checked).is_ok_and(|m| m.file_type().is_symlink()) {
+            return None;
+        }
+    }
+    let text = relative.to_str()?;
+    let lower = text.to_ascii_lowercase();
+    if text.len() > 512
+        || text.chars().any(char::is_control)
+        || lower.split('/').any(|p| {
+            p.starts_with('.')
+                || [
+                    "credentials",
+                    "credentials.json",
+                    "secrets",
+                    "auth.json",
+                    "id_rsa",
+                    "id_ed25519",
+                ]
+                .contains(&p)
+        })
+        || [".pem", ".key", ".p12", ".pfx", ".env"]
+            .iter()
+            .any(|ext| lower.ends_with(ext))
+    {
+        return None;
+    }
+    Some(text.into())
+}
+fn redacted_diff(diff: &str) -> (String, bool) {
+    let mut output = String::new();
+    let mut truncated = false;
+    let secret = regex::Regex::new(r"(?i)(api.?key|secret|password|passwd|authorization|bearer\s|access.?token|refresh.?token|\btoken\b|private.?key|sk-[a-z0-9]|gh[pousr]_|AKIA[0-9A-Z])").expect("constant regex");
+    let mut private_key = false;
+    for line in diff.lines() {
+        if line.contains("-----BEGIN ") && line.contains("PRIVATE KEY-----") {
+            private_key = true;
+        }
+        let redact = private_key || secret.is_match(line);
+        if line.contains("-----END ") && line.contains("PRIVATE KEY-----") {
+            private_key = false;
+        }
+        let line = if redact {
+            "[sensitive line redacted]"
+        } else {
+            line
+        };
+        if output.len() + line.len() > 16_384 {
+            truncated = true;
+            break;
+        }
+        output.extend(line.chars().filter(|c| !c.is_control() || *c == '\t'));
+        output.push('\n');
+    }
+    (output, truncated)
+}
+
+/// Keeps backend turn identity separate from the runtime invocation. A pane
+/// may have bootstrap turns; history is never attributed merely by proximity.
+struct Capture {
+    run: ActivityRun,
+    invocation: String,
+    thread: String,
+    baseline: BTreeSet<String>,
+    turns: BTreeSet<String>,
+    finished_items: BTreeSet<String>,
+    started_items: BTreeSet<String>,
+}
+impl Capture {
+    fn accept_turn(&mut self, turn: &Value) -> bool {
+        let Some(id) = turn["id"].as_str() else {
+            return false;
+        };
+        if self.turns.contains(id) {
+            return true;
+        }
+        if self.baseline.contains(id) {
+            return false;
+        }
+        // The delivered user item carries the runtime's opaque invocation ID.
+        // Time alone cannot attribute bootstrap/manual turns in the same pane.
+        let marker = format!("invocation_id: {}", self.invocation);
+        if turn["items"].as_array().into_iter().flatten().any(|item| {
+            item["type"] == "userMessage"
+                && item["content"]
+                    .as_array()
+                    .into_iter()
+                    .flatten()
+                    .any(|part| {
+                        part["text"]
+                            .as_str()
+                            .is_some_and(|text| text.lines().any(|line| line.trim() == marker))
+                    })
+        }) {
+            self.turns.insert(id.into());
+            return true;
+        }
+        false
+    }
+    fn notification(&mut self, value: &Value) {
+        let p = &value["params"];
+        if p["threadId"].as_str() != Some(&self.thread) {
+            return;
+        }
+        match value["method"].as_str().unwrap_or("") {
+            "turn/started" | "turn/completed" => {
+                self.accept_turn(&p["turn"]);
+            }
+            "item/started" | "item/completed" => {
+                // Live user-item events also establish attribution when the
+                // backend can subscribe but cannot hydrate full history.
+                self.accept_turn(&json!({"id":p["turnId"], "items":[p["item"].clone()]}));
+                let Some(turn) = p["turnId"].as_str().filter(|id| self.turns.contains(*id)) else {
+                    return;
+                };
+                let completed = value["method"] == "item/completed";
+                let at = p[if completed {
+                    "completedAtMs"
+                } else {
+                    "startedAtMs"
+                }]
+                .as_u64();
+                self.item(turn, &p["item"], completed, at, false);
+            }
+            // Reasoning and raw deltas intentionally have no path into the API.
+            _ => {}
+        }
+    }
+    fn reconcile(&mut self, thread: &Value) {
+        self.run.update(&self.invocation, |i| {
+            i.reported_thread_settings = RoleSelection {
+                model: thread["model"]
+                    .as_str()
+                    .filter(|s| safe_identifier(s))
+                    .map(str::to_string),
+                effort: thread["reasoningEffort"]
+                    .as_str()
+                    .filter(|s| safe_identifier(s))
+                    .map(str::to_string),
+            };
+        });
+        for turn in thread["turns"].as_array().into_iter().flatten() {
+            if !self.accept_turn(turn) {
+                continue;
+            }
+            let id = turn["id"].as_str().unwrap_or_default();
+            for item in turn["items"].as_array().into_iter().flatten() {
+                let status = item["status"].as_str().unwrap_or("");
+                if matches!(status, "inProgress" | "completed" | "failed" | "declined") {
+                    self.item(id, item, status != "inProgress", None, true);
+                }
+            }
+            if matches!(turn["status"].as_str(), Some("failed" | "interrupted")) {
+                self.run.update(&self.invocation, |i| event(i, ActivityEvent {
+                    id: format!("{id}:error"), at: now_ms(), time_source: "observed".into(), kind: "error".into(), summary: "Backend turn ended with an error or interruption · inspect terminal".into(), tool_id: None, exit_code: None,
+                }));
+            }
+        }
+    }
+    fn item(
+        &mut self,
+        turn: &str,
+        item: &Value,
+        completed: bool,
+        at: Option<u64>,
+        recovered: bool,
+    ) {
+        let Some(summary) = tool_summary(item) else {
+            return;
+        };
+        let Some(item_id) = item["id"].as_str() else {
+            return;
+        };
+        let key = format!("{}:{turn}:{item_id}", self.thread);
+        if completed {
+            if !self.finished_items.insert(key.clone()) {
+                return;
+            }
+        } else if self.finished_items.contains(&key) || !self.started_items.insert(key.clone()) {
+            return;
+        }
+        let root = &self.run.workdir;
+        self.run.update(&self.invocation, |i| {
+            let observed = now_ms();
+            if completed {
+                i.active_tools.retain(|tool| tool.id != key);
+            } else if !i.active_tools.iter().any(|tool| tool.id == key) {
+                i.active_tools.push(ObservedTool {
+                    id: key.clone(),
+                    summary: summary.clone(),
+                    started_at: at,
+                    observed_at: observed,
+                });
+            }
+            let failed = !item["error"].is_null()
+                || item["result"]["isError"] == true
+                || matches!(item["status"].as_str(), Some("failed" | "declined"))
+                || item["exitCode"].as_i64().is_some_and(|c| c != 0);
+            let description = if completed {
+                format!("{summary} · {}", if failed { "failed" } else { "finished" })
+            } else {
+                summary
+            };
+            event(
+                i,
+                ActivityEvent {
+                    id: format!("{key}:{}", if completed { "end" } else { "start" }),
+                    at: at.unwrap_or(observed),
+                    time_source: if at.is_some() {
+                        "backend"
+                    } else if recovered {
+                        "recovered"
+                    } else {
+                        "observed"
+                    }
+                    .into(),
+                    kind: if failed {
+                        "error"
+                    } else if completed {
+                        "tool_finished"
+                    } else {
+                        "tool_started"
+                    }
+                    .into(),
+                    summary: description,
+                    tool_id: Some(key.clone()),
+                    exit_code: item["exitCode"].as_i64(),
+                },
+            );
+            if completed && !failed && item["type"] == "fileChange" && item["status"] == "completed"
+            {
+                for change in item["changes"].as_array().into_iter().flatten().take(100) {
+                    let Some(path) = change["path"].as_str().and_then(|s| scoped_path(s, root))
+                    else {
+                        continue;
+                    };
+                    let id = format!("{key}:{path}");
+                    if i.artifacts.iter().any(|a| a.id == id) {
+                        continue;
+                    }
+                    let (diff, diff_truncated) =
+                        redacted_diff(change["diff"].as_str().unwrap_or_default());
+                    let kind = match change["kind"]["type"].as_str() {
+                        Some("add") => "created",
+                        Some("delete") => "deleted",
+                        _ => "modified",
+                    };
+                    i.artifacts.push(ChangedArtifact {
+                        id,
+                        path,
+                        change: kind.into(),
+                        observed_at: at.unwrap_or(observed),
+                        diff: (!diff.is_empty()).then_some(diff),
+                        diff_truncated,
+                        verification:
+                            "Not verified by Omar; inspect check outcomes in the timeline".into(),
+                    });
+                    if i.artifacts.len() > 30 {
+                        i.artifacts.remove(0);
+                    }
+                }
+            }
+        });
+    }
+}
+
+/// New or paginated threads may support metadata while refusing full
+/// history. Keep configuration and connectivity usable in that case.
+fn read_activity(session: &mut CodexSession, thread: &str) -> Result<(Value, bool)> {
+    match session.call(
+        "thread/read",
+        json!({"threadId":thread, "includeTurns":true}),
+    ) {
+        Ok(read) => Ok((read, true)),
+        Err(_) => session
+            .call(
+                "thread/read",
+                json!({"threadId":thread, "includeTurns":false}),
+            )
+            .map(|read| (read, false)),
+    }
+}
+
+/// One monitor per active invocation. Read-only except an explicitly requested
+/// next-invocation model/effort delivered with turn/start by `deliver_configured`.
+pub struct InvocationMonitor {
+    run: ActivityRun,
+    id: String,
+    socket: Option<PathBuf>,
+    source: Option<(TmuxClient, String)>,
+    capture: Option<Capture>,
+    session: Option<CodexSession>,
+    subscribed: bool,
+}
+impl InvocationMonitor {
+    pub fn prepare(run: ActivityRun, id: &str, client: &TmuxClient, agent: &str) -> Self {
+        let mut monitor = Self {
+            run,
+            id: id.into(),
+            socket: codex_socket(client, agent),
+            source: Some((client.clone(), agent.into())),
+            capture: None,
+            session: None,
+            subscribed: false,
+        };
+        if monitor
+            .run
+            .backends
+            .get(agent)
+            .is_some_and(|b| b == "codex")
+            && monitor.connect(true).is_err()
+        {
+            monitor.run.connection(id, ActivityConnection::Disconnected);
+        }
+        monitor
+    }
+    fn connect(&mut self, baseline: bool) -> Result<()> {
+        if let Some((client, agent)) = &self.source {
+            self.socket = codex_socket(client, agent);
+        }
+        let mut session =
+            CodexSession::open(self.socket.as_deref().context("no app-server socket")?)?;
+        let thread_id = session.only_thread()?;
+        let (read, history_available) = read_activity(&mut session, &thread_id)?;
+        if self.capture.as_ref().is_some_and(|c| c.thread != thread_id) {
+            bail!("pane changed threads; activity attribution unavailable");
+        }
+        if self.capture.is_none() {
+            self.capture = Some(Capture {
+                run: self.run.clone(),
+                invocation: self.id.clone(),
+                thread: thread_id.clone(),
+                baseline: if baseline {
+                    read["thread"]["turns"]
+                        .as_array()
+                        .into_iter()
+                        .flatten()
+                        .filter_map(|t| t["id"].as_str().map(str::to_string))
+                        .collect()
+                } else {
+                    BTreeSet::new()
+                },
+                turns: BTreeSet::new(),
+                finished_items: BTreeSet::new(),
+                started_items: BTreeSet::new(),
+            });
+        }
+        // No overrides: this only subscribes to the pane's existing thread.
+        self.subscribed = session
+            .call(
+                "thread/resume",
+                json!({"threadId": thread_id, "excludeTurns": true}),
+            )
+            .is_ok();
+        if !self.subscribed {
+            // A history capability refusal is not a lost connection. Verify
+            // the metadata channel still works before retaining this session.
+            session.call(
+                "thread/read",
+                json!({"threadId": thread_id, "includeTurns": false}),
+            )?;
+        }
+        let capture = self.capture.as_mut().unwrap();
+        for value in session.take_notifications() {
+            capture.notification(&value);
+        }
+        capture.reconcile(&read["thread"]);
+        self.run.connection(
+            &self.id,
+            if history_available || self.subscribed {
+                ActivityConnection::Connected
+            } else {
+                ActivityConnection::Unsupported
+            },
+        );
+        self.session = Some(session);
+        Ok(())
+    }
+    pub fn deliver_configured(&mut self, message: &str) -> Result<bool> {
+        let requested = self.run.requested(&self.id);
+        if requested.model.is_none() {
+            return Ok(false);
+        }
+        let session = self.session.as_mut().context(
+            "requested settings require a connected app-server; invocation was not sent",
+        )?;
+        let capture = self.capture.as_mut().context("missing monitor")?;
+        let models = supported_models(session)?;
+        validate_selection(&requested, &models)?;
+        let effort = requested.effort.clone().or_else(|| {
+            models
+                .iter()
+                .find(|m| Some(&m.model) == requested.model.as_ref())
+                .and_then(|m| m.default_effort.clone())
+        });
+        let read = session.call(
+            "thread/read",
+            json!({"threadId": capture.thread, "includeTurns": false}),
+        )?;
+        anyhow::ensure!(
+            read["thread"]["status"]["type"] == "idle",
+            "agent is already active; next-invocation settings were not sent"
+        );
+        // Never retry a turn/start failure with terminal delivery: a lost reply
+        // may already have started the turn. Nor change permission settings.
+        let response = session.call("turn/start", json!({"threadId": capture.thread, "input": [{"type":"text", "text":message, "text_elements":[]}], "model": requested.model, "effort": effort}))?;
+        let turn = response["turn"]["id"]
+            .as_str()
+            .context("turn/start did not return a turn id")?;
+        capture.turns.insert(turn.into());
+        self.run.application(
+            &self.id,
+            "Requested settings accepted by turn/start; active execution settings not reported",
+        );
+        Ok(true)
+    }
+    pub fn spawn(mut self) -> MonitorGuard {
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let stopped = stop.clone();
+        if !self
+            .run
+            .snapshot()
+            .invocations
+            .iter()
+            .any(|i| i.invocation_id == self.id && i.backend == "codex")
+        {
+            return MonitorGuard { stop, thread: None };
+        }
+        let thread = std::thread::spawn(move || {
+            while self.run.active(&self.id) {
+                let last = stopped.load(std::sync::atomic::Ordering::Acquire);
+                if self.session.is_none() && self.connect(false).is_err() {
+                    self.run
+                        .connection(&self.id, ActivityConnection::Disconnected);
+                    if last {
+                        break;
+                    }
+                    std::thread::sleep(Duration::from_secs(1));
+                    continue;
+                }
+                let session = self.session.as_mut().unwrap();
+                let capture = self.capture.as_mut().unwrap();
+                match read_activity(session, &capture.thread) {
+                    Ok((read, history_available)) => {
+                        if !self.subscribed && history_available {
+                            self.subscribed = session
+                                .call(
+                                    "thread/resume",
+                                    json!({"threadId": capture.thread, "excludeTurns":true}),
+                                )
+                                .is_ok();
+                        }
+                        for turn in read["thread"]["turns"].as_array().into_iter().flatten() {
+                            capture.accept_turn(turn);
+                        }
+                        for value in session.take_notifications() {
+                            capture.notification(&value);
+                        }
+                        capture.reconcile(&read["thread"]);
+                        self.run.connection(
+                            &self.id,
+                            if history_available || self.subscribed {
+                                ActivityConnection::Connected
+                            } else {
+                                ActivityConnection::Unsupported
+                            },
+                        );
+                    }
+                    Err(_) => {
+                        self.session = None;
+                        self.run
+                            .connection(&self.id, ActivityConnection::Disconnected);
+                    }
+                }
+                if last {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(500));
+            }
+        });
+        MonitorGuard {
+            stop,
+            thread: Some(thread),
+        }
+    }
+}
+pub struct MonitorGuard {
+    stop: Arc<std::sync::atomic::AtomicBool>,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+impl Drop for MonitorGuard {
+    fn drop(&mut self) {
+        self.stop.store(true, std::sync::atomic::Ordering::Release);
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn run(root: &Path) -> ActivityRun {
+        ActivityRun::new(
+            "run".into(),
+            "Team".into(),
+            BTreeMap::from([
+                ("one".into(), "codex".into()),
+                ("two".into(), "codex".into()),
+            ]),
+            RoleSettings::load(root.join("roles.json")),
+            root.into(),
+        )
+    }
+    fn capture(run: &ActivityRun, id: &str) -> Capture {
+        Capture {
+            run: run.clone(),
+            invocation: id.into(),
+            thread: format!("thread-{id}"),
+            baseline: BTreeSet::new(),
+            turns: BTreeSet::from(["turn".into()]),
+            finished_items: BTreeSet::new(),
+            started_items: BTreeSet::new(),
+        }
+    }
+    fn command(status: &str, exit: Value) -> Value {
+        json!({"id":"same-item", "type":"commandExecution", "command":"SECRET=do-not-display command --token=hidden", "aggregatedOutput":"private output", "status":status, "exitCode":exit})
+    }
+    #[test]
+    fn concurrent_agents_tools_disconnect_and_late_events_stay_independent() {
+        let dir = tempfile::tempdir().unwrap();
+        let run = run(dir.path());
+        run.start("a", "r.0", "one");
+        run.start("b", "r.1", "two");
+        let mut a = capture(&run, "a");
+        let mut b = capture(&run, "b");
+        a.item(
+            "turn",
+            &command("inProgress", Value::Null),
+            false,
+            Some(1000),
+            false,
+        );
+        b.item(
+            "turn",
+            &command("inProgress", Value::Null),
+            false,
+            Some(2000),
+            false,
+        );
+        run.connection("a", ActivityConnection::Disconnected);
+        assert_eq!(
+            run.snapshot().invocations[0].active_tools[0].started_at,
+            Some(1000)
+        );
+        // Snapshot/reload is non-destructive, and does not refresh last activity.
+        let before = run.snapshot().invocations[0].last_activity_at;
+        run.connection("a", ActivityConnection::Connected);
+        assert_eq!(run.snapshot().invocations[0].last_activity_at, before);
+        b.item(
+            "turn",
+            &command("completed", json!(0)),
+            true,
+            Some(3000),
+            false,
+        );
+        run.finish("b", true, 1);
+        let finished = run.snapshot().invocations[1].finished_at;
+        b.item(
+            "turn",
+            &command("inProgress", Value::Null),
+            false,
+            Some(4000),
+            false,
+        );
+        run.start("b", "r.1", "two");
+        let snapshot = run.snapshot();
+        assert_eq!(
+            snapshot.invocations[0].execution,
+            ActivityExecution::Running
+        );
+        assert_eq!(snapshot.invocations[0].active_tools.len(), 1);
+        assert_eq!(snapshot.invocations[1].finished_at, finished);
+        assert!(snapshot.invocations[1].active_tools.is_empty());
+        assert_eq!(snapshot.invocations.len(), 2);
+        assert!(!serde_json::to_string(&snapshot)
+            .unwrap()
+            .contains("do-not-display"));
+        assert!(!serde_json::to_string(&snapshot)
+            .unwrap()
+            .contains("private output"));
+    }
+    #[test]
+    fn duplicate_and_delayed_starts_do_not_reopen_finished_tools() {
+        let dir = tempfile::tempdir().unwrap();
+        let run = run(dir.path());
+        run.start("a", "r", "one");
+        let mut c = capture(&run, "a");
+        c.item(
+            "turn",
+            &command("completed", json!(1)),
+            true,
+            Some(3000),
+            false,
+        );
+        c.item(
+            "turn",
+            &command("completed", json!(1)),
+            true,
+            Some(3000),
+            false,
+        );
+        c.item(
+            "turn",
+            &command("inProgress", Value::Null),
+            false,
+            Some(2000),
+            false,
+        );
+        let i = &run.snapshot().invocations[0];
+        assert!(i.active_tools.is_empty());
+        assert_eq!(i.events.len(), 2);
+        assert!(i
+            .events
+            .iter()
+            .any(|e| e.kind == "error" && e.exit_code == Some(1)));
+    }
+    #[test]
+    fn artifacts_need_successful_scoped_tool_evidence_and_redact_secrets() {
+        let dir = tempfile::tempdir().unwrap();
+        let run = run(dir.path());
+        run.start("a", "r", "one");
+        let mut c = capture(&run, "a");
+        let mut item = json!({"id":"edit","type":"fileChange", "status":"inProgress", "changes":[
+            {"path":"src/api.rs","kind":{"type":"add"},"diff":"+ fn works() {}\n+ api_key=SECRET\n+ -----BEGIN PRIVATE KEY-----\n+ hidden-key\n+ -----END PRIVATE KEY-----\n"},
+            {"path":".env","kind":{"type":"add"},"diff":"secret"},
+            {"path":"../other.rs","kind":{"type":"update"},"diff":"outside"},
+            {"path":"/etc/passwd","kind":{"type":"update"},"diff":"outside"}
+        ]});
+        c.item("turn", &item, false, Some(2000), false);
+        assert!(run.snapshot().invocations[0].artifacts.is_empty());
+        item["status"] = json!("completed");
+        c.item("turn", &item, true, Some(3000), false);
+        let snapshot = run.snapshot();
+        let artifacts = &snapshot.invocations[0].artifacts;
+        assert_eq!(artifacts.len(), 1);
+        assert_eq!(artifacts[0].change, "created");
+        assert!(artifacts[0].diff.as_ref().unwrap().contains("fn works"));
+        let serialized = serde_json::to_string(&snapshot).unwrap();
+        for secret in ["SECRET", "hidden-key", "outside", ".env"] {
+            assert!(!serialized.contains(secret));
+        }
+        assert!(artifacts[0].verification.starts_with("Not verified"));
+    }
+    #[test]
+    fn recovery_only_attributes_turns_with_the_runtime_invocation_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let run = run(dir.path());
+        run.start("a", "r", "one");
+        let mut c = capture(&run, "a");
+        let bootstrap = json!({"id":"bootstrap", "startedAt": now_ms()/1000, "items": [command("completed", json!(0))]});
+        assert!(!c.accept_turn(&bootstrap));
+        let matched = json!({"id":"matching", "items":[{"type":"userMessage","content":[{"type":"text","text":"OMAR INVOCATION\ninvocation_id: a\n"}]}, command("inProgress", Value::Null)]});
+        c.reconcile(
+            &json!({"turns":[bootstrap, matched], "model":"supported", "reasoningEffort":"high"}),
+        );
+        let i = &run.snapshot().invocations[0];
+        assert_eq!(i.active_tools.len(), 1);
+        assert_eq!(i.active_tools[0].started_at, None);
+        assert!(i.events.iter().any(|e| e.time_source == "recovered"));
+        assert_eq!(i.confirmed, RoleSelection::default());
+        assert_eq!(
+            i.reported_thread_settings.model.as_deref(),
+            Some("supported")
+        );
+    }
+    #[test]
+    fn reasoning_and_ordinary_questions_have_no_activity_projection() {
+        let dir = tempfile::tempdir().unwrap();
+        let run = run(dir.path());
+        run.start("a", "r", "one");
+        let mut c = capture(&run, "a");
+        for method in [
+            "item/reasoning/textDelta",
+            "item/tool/requestUserInput",
+            "item/agentMessage/delta",
+        ] {
+            c.notification(&json!({"method":method,"params":{"threadId":"thread-a","turnId":"turn","text":"private reasoning"}}));
+        }
+        assert_eq!(run.snapshot().invocations[0].events.len(), 1);
+    }
+    #[test]
+    fn requested_roles_persist_but_cannot_change_an_active_invocation() {
+        let dir = tempfile::tempdir().unwrap();
+        let run = run(dir.path());
+        run.start("a", "r", "one");
+        let models = vec![SupportedModel {
+            model: "available".into(),
+            name: "Available".into(),
+            efforts: vec!["medium".into()],
+            default_effort: Some("medium".into()),
+        }];
+        let role = SavedRoleSettings {
+            team: "Team".into(),
+            agent: "one".into(),
+            backend: "codex".into(),
+            selection: RoleSelection {
+                model: Some("available".into()),
+                effort: Some("medium".into()),
+            },
+        };
+        run.settings.save(role.clone(), &models).unwrap();
+        assert_eq!(run.requested("a"), RoleSelection::default());
+        run.finish("a", true, 0);
+        run.start("b", "r", "one");
+        assert_eq!(run.requested("b"), role.selection);
+        let reloaded = RoleSettings::load(dir.path().join("roles.json"));
+        assert_eq!(reloaded.requested("Team", "one", "codex"), role.selection);
+        let mut unsupported = role.clone();
+        unsupported.selection.effort = Some("ultra".into());
+        assert!(run.settings.save(unsupported, &models).is_err());
+        let mut unsupported = role;
+        unsupported.backend = "stub".into();
+        assert!(run.settings.save(unsupported, &models).is_err());
+    }
+    #[test]
+    fn unix_socket_fixture_tests_subscription_and_confirmed_turn_start_without_permission_overrides(
+    ) {
+        use std::os::unix::net::UnixListener;
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("app.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let mut ws = tungstenite::accept(stream).unwrap();
+            let mut methods = Vec::new();
+            loop {
+                let message = ws.read().unwrap();
+                let tungstenite::Message::Text(body) = message else {
+                    continue;
+                };
+                let request: Value = serde_json::from_str(&body).unwrap();
+                let method = request["method"].as_str().unwrap();
+                methods.push(method.to_string());
+                let result = match method {
+                    "initialize" => json!({}),
+                    "initialized" => continue,
+                    "thread/loaded/list" => json!({"data":["thread-a"]}),
+                    "thread/read" => {
+                        if request["params"]["includeTurns"] == true {
+                            ws.send(tungstenite::Message::Text(json!({"id":request["id"], "error":{"code":-32600,"message":"not materialized yet"}}).to_string())).unwrap();
+                            continue;
+                        }
+                        json!({"thread":{"id":"thread-a","status":{"type":"idle"},"turns":[]}})
+                    }
+                    "thread/resume" => {
+                        assert_eq!(
+                            request["params"],
+                            json!({"threadId":"thread-a", "excludeTurns":true})
+                        );
+                        ws.send(tungstenite::Message::Text(json!({"id":request["id"], "error":{"code":-32600,"message":"no rollout found"}}).to_string())).unwrap();
+                        continue;
+                    }
+                    "model/list" => {
+                        json!({"data":[{"model":"available","defaultReasoningEffort":"medium","supportedReasoningEfforts":[{"reasoningEffort":"medium"}]}],"nextCursor":null})
+                    }
+                    "turn/start" => {
+                        assert_eq!(request["params"]["model"], "available");
+                        assert_eq!(request["params"]["effort"], "medium");
+                        for forbidden in ["approvalPolicy", "approvalsReviewer", "sandboxPolicy"] {
+                            assert!(request["params"].get(forbidden).is_none());
+                        }
+                        json!({"turn":{"id":"turn"}})
+                    }
+                    _ => panic!("unexpected request {method}"),
+                };
+                ws.send(tungstenite::Message::Text(
+                    json!({"id":request["id"],"result":result}).to_string(),
+                ))
+                .unwrap();
+                if method == "turn/start" {
+                    return methods;
+                }
+            }
+        });
+        let run = run(dir.path());
+        run.settings
+            .save(
+                SavedRoleSettings {
+                    team: "Team".into(),
+                    agent: "one".into(),
+                    backend: "codex".into(),
+                    selection: RoleSelection {
+                        model: Some("available".into()),
+                        effort: None,
+                    },
+                },
+                &[SupportedModel {
+                    model: "available".into(),
+                    name: "Available".into(),
+                    efforts: vec!["medium".into()],
+                    default_effort: Some("medium".into()),
+                }],
+            )
+            .unwrap();
+        run.start("a", "r", "one");
+        let mut monitor = InvocationMonitor {
+            run: run.clone(),
+            id: "a".into(),
+            socket: Some(socket),
+            source: None,
+            capture: None,
+            session: None,
+            subscribed: false,
+        };
+        monitor.connect(true).unwrap();
+        assert_eq!(
+            run.snapshot().invocations[0].connection,
+            ActivityConnection::Unsupported
+        );
+        assert!(monitor
+            .deliver_configured("OMAR INVOCATION\ninvocation_id: a")
+            .unwrap());
+        assert!(run.snapshot().invocations[0]
+            .settings_application
+            .contains("accepted by turn/start"));
+        assert_eq!(
+            run.snapshot().invocations[0].confirmed,
+            RoleSelection::default()
+        );
+        assert_eq!(
+            server.join().unwrap(),
+            vec![
+                "initialize",
+                "initialized",
+                "thread/loaded/list",
+                "thread/read",
+                "thread/read",
+                "thread/resume",
+                "thread/read",
+                "model/list",
+                "thread/read",
+                "turn/start"
+            ]
+        );
+    }
+    #[test]
+    fn bounded_timeline_replay_does_not_turn_old_work_into_new_activity() {
+        let dir = tempfile::tempdir().unwrap();
+        let run = run(dir.path());
+        run.start("a", "r", "one");
+        let mut c = capture(&run, "a");
+        for number in 0..250 {
+            let mut item = command("completed", json!(0));
+            item["id"] = json!(format!("item-{number}"));
+            c.item("turn", &item, true, Some(now_ms()), false);
+        }
+        let before = run.snapshot();
+        assert_eq!(before.invocations[0].events.len(), 200);
+        for number in 0..250 {
+            let mut item = command("completed", json!(0));
+            item["id"] = json!(format!("item-{number}"));
+            c.item("turn", &item, true, None, true);
+        }
+        let after = run.snapshot();
+        assert_eq!(before.sequence, after.sequence);
+        assert_eq!(
+            before.invocations[0].last_activity_at,
+            after.invocations[0].last_activity_at
+        );
+    }
+}

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -530,14 +530,15 @@ fn provision_codex(home: &Path) -> Option<String> {
 /// performs the upgrade: it wants a URL only to build the request line and
 /// `Host` header, so a placeholder is fine — the bytes go wherever the stream
 /// already points, which here is a socket path.
-struct CodexSession {
+pub(crate) struct CodexSession {
     socket: tungstenite::WebSocket<UnixStream>,
     next_id: u64,
+    notifications: Vec<serde_json::Value>,
 }
 
 impl CodexSession {
     /// Connect, upgrade, and complete the app-server's opening handshake.
-    fn open(path: &Path) -> Result<CodexSession> {
+    pub(crate) fn open(path: &Path) -> Result<CodexSession> {
         let stream =
             UnixStream::connect(path).with_context(|| format!("connect to {}", path.display()))?;
         stream.set_read_timeout(Some(WRITE_TIMEOUT))?;
@@ -559,7 +560,11 @@ impl CodexSession {
             }
         })?;
 
-        let mut session = CodexSession { socket, next_id: 1 };
+        let mut session = CodexSession {
+            socket,
+            next_id: 1,
+            notifications: Vec::new(),
+        };
         session
             .call(
                 "initialize",
@@ -594,7 +599,11 @@ impl CodexSession {
     ///
     /// The server pushes notifications of its own down the same socket, so a
     /// reply is found by id rather than by being the next message.
-    fn call(&mut self, method: &str, params: serde_json::Value) -> Result<serde_json::Value> {
+    pub(crate) fn call(
+        &mut self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value> {
         let id = self.next_id;
         self.next_id += 1;
         self.send(serde_json::json!({
@@ -612,6 +621,17 @@ impl CodexSession {
             let Ok(value) = serde_json::from_str::<serde_json::Value>(&body) else {
                 continue;
             };
+            if value.get("method").is_some() {
+                // Bounded: readers project only allowlisted lifecycle events.
+                if matches!(
+                    value["method"].as_str(),
+                    Some("turn/started" | "turn/completed" | "item/started" | "item/completed")
+                ) && self.notifications.len() < 2048
+                {
+                    self.notifications.push(value);
+                }
+                continue;
+            }
             if value.get("id").and_then(serde_json::Value::as_u64) != Some(id) {
                 continue;
             }
@@ -622,8 +642,12 @@ impl CodexSession {
         }
     }
 
+    pub(crate) fn take_notifications(&mut self) -> Vec<serde_json::Value> {
+        std::mem::take(&mut self.notifications)
+    }
+
     /// The thread the pane is showing, when that is unambiguous.
-    fn only_thread(&mut self) -> Result<String> {
+    pub(crate) fn only_thread(&mut self) -> Result<String> {
         let listed = self.call("thread/loaded/list", serde_json::json!({}))?;
         only_thread(&listed).context("the pane has no single loaded thread to inject into")
     }

--- a/src/omar.rs
+++ b/src/omar.rs
@@ -1,3 +1,4 @@
+mod activity;
 mod app;
 mod backend_probe;
 mod channel;
@@ -500,6 +501,7 @@ async fn async_main() -> Result<()> {
             topology::run_topology(
                 &bytecode,
                 topology::TopologyRunConfig {
+                    activity: None,
                     ea_id: target.id,
                     omar_dir: &omar_dir,
                     base_prefix: &config.dashboard.session_prefix,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -23,6 +23,7 @@
 //! runtime one — a hand-written list inside `assertRunRecord`. The array is
 //! what that check can be written against.
 
+use crate::activity::*;
 use ts_rs::{Config, TS};
 
 use crate::diagram::{
@@ -76,6 +77,8 @@ fn vocabulary<T: serde::Serialize>(
 
 fn vocabularies() -> Vec<Vocabulary> {
     vec![
+        vocabulary("ACTIVITY_EXECUTIONS", "ActivityExecution", "Runtime invocation outcome, independent of monitoring.", &[ActivityExecution::Running, ActivityExecution::Completed, ActivityExecution::Failed]),
+        vocabulary("ACTIVITY_CONNECTIONS", "ActivityConnection", "Availability of the backend monitoring connection.", &[ActivityConnection::Connecting, ActivityConnection::Connected, ActivityConnection::Disconnected, ActivityConnection::Unsupported]),
         vocabulary(
             "RUN_STATUSES",
             "RunStatus",
@@ -174,6 +177,15 @@ pub fn generate() -> String {
 
     // Declared after the vocabularies, because the structs refer to them.
     let mut decls = vec![
+        ActivityEvent::decl(&config),
+        ObservedTool::decl(&config),
+        ChangedArtifact::decl(&config),
+        RoleSelection::decl(&config),
+        InvocationActivity::decl(&config),
+        ActivitySnapshot::decl(&config),
+        SupportedModel::decl(&config),
+        SavedRoleSettings::decl(&config),
+        RoleSettingsSnapshot::decl(&config),
         DiagramTag::decl(&config),
         DiagramInstance::decl(&config),
         DiagramAgent::decl(&config),

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -194,6 +194,8 @@ struct Context_ {
     /// whose program has no `Web` agent, which is what makes the panel routes
     /// 404 rather than offer an empty panel.
     panels: Panels,
+    activity: Arc<Mutex<BTreeMap<String, crate::activity::ActivityRun>>>,
+    role_settings: crate::activity::RoleSettings,
     chat: Arc<Mutex<Chat>>,
     /// Authenticates the EA's MCP sidecar on the agent-only endpoints.
     agent_token: String,
@@ -290,6 +292,10 @@ impl Serve {
             health_idle_warning: config.health.idle_warning,
             runs: Runs::default(),
             panels: Panels::default(),
+            activity: Arc::new(Mutex::new(BTreeMap::new())),
+            role_settings: crate::activity::RoleSettings::load(
+                omar_dir.join(format!("role-settings-{ea_id}.json")),
+            ),
             chat: Arc::new(Mutex::new(Chat::default())),
             agent_token: agent_token.clone(),
             command: Arc::new(Mutex::new(config.agent.default_command.clone())),
@@ -607,6 +613,45 @@ fn handle_client(mut stream: TcpStream, context: Arc<Context_>) -> Result<()> {
         }
         ("POST", "/v1/chat") => send_to_ea(&context, &read_body(content_length)?),
         ("GET", "/v1/agent") => (200, describe_agent(&context)),
+        ("GET", "/v1/role-settings") => {
+            let models = activity_models(&context);
+            (
+                200,
+                json!(crate::activity::RoleSettingsSnapshot {
+                    roles: context.role_settings.all(),
+                    capabilities_available: !models.is_empty(),
+                    codex_models: models,
+                }),
+            )
+        }
+        ("POST", "/v1/role-settings") if content_length > 16 * 1024 => {
+            (413, json!({"error":"role settings body too large"}))
+        }
+        ("POST", "/v1/role-settings") => {
+            match serde_json::from_slice::<crate::activity::SavedRoleSettings>(&read_body(
+                content_length,
+            )?) {
+                Ok(role) => match context.role_settings.save(role, &activity_models(&context)) {
+                    Ok(()) => (200, json!({"saved":true, "applies_to":"next_invocation"})),
+                    Err(error) => (400, json!({"error":error.to_string()})),
+                },
+                Err(_) => (400, json!({"error":"invalid role settings"})),
+            }
+        }
+        ("GET", rest) if rest.starts_with("/v1/runs/") && rest.ends_with("/activity") => {
+            let id = rest
+                .trim_start_matches("/v1/runs/")
+                .trim_end_matches("/activity");
+            match context
+                .activity
+                .lock()
+                .expect("activity runs poisoned")
+                .get(id)
+            {
+                Some(activity) => (200, json!(activity.snapshot())),
+                None => (404, json!({"error":"activity unavailable for this run"})),
+            }
+        }
         ("POST", "/v1/agent/backend") => switch_backend(&context, &read_body(content_length)?),
         // EA-only, authenticated with the token handed to its MCP sidecar.
         ("POST", "/v1/agent/reply") => agent_reply(&context, &read_body(content_length)?),
@@ -1398,6 +1443,42 @@ fn panel_answer(context: &Arc<Context_>, run_id: &str, body: &[u8]) -> (u16, Val
     }
 }
 
+/// Discover capabilities from an existing pane only; this never launches an
+/// agent, changes its backend, or treats a cached catalog as live support.
+fn activity_models(context: &Context_) -> Vec<crate::activity::SupportedModel> {
+    let client = TmuxClient::new(crate::ea::ea_prefix(context.ea_id, &context.session_prefix));
+    let ea = crate::ea::ea_manager_session(context.ea_id, &context.session_prefix);
+    let mut sockets = Vec::new();
+    if let Some(stamp) = client.session_delivery(&ea) {
+        if let Some(path) = stamp.strip_prefix("codex:") {
+            sockets.push(PathBuf::from(path));
+        }
+    }
+    let agents: Vec<String> = context
+        .activity
+        .lock()
+        .expect("activity runs poisoned")
+        .values()
+        .flat_map(|run| {
+            run.backends
+                .iter()
+                .filter(|(_, b)| b.as_str() == "codex")
+                .map(|(a, _)| a.clone())
+        })
+        .collect();
+    for agent in agents {
+        if let Some(socket) = crate::activity::codex_socket(&client, &agent) {
+            sockets.push(socket);
+        }
+    }
+    for socket in sockets {
+        if let Ok(models) = crate::activity::models_from_socket(&socket) {
+            return models;
+        }
+    }
+    Vec::new()
+}
+
 fn spawn_run_thread(
     context: &Arc<Context_>,
     run_id: &str,
@@ -1431,11 +1512,34 @@ fn spawn_run_thread(
     } else {
         topology::Pace::RealTime
     };
+    let state = topology::verify(&bytecode).expect("admitted bytecode is verified");
+    let activity = crate::activity::ActivityRun::new(
+        run_id.clone(),
+        state.team.clone(),
+        state
+            .agents
+            .iter()
+            .map(|(name, agent)| {
+                (
+                    name.clone(),
+                    topology::canonical_backend(&agent.backend).to_string(),
+                )
+            })
+            .collect(),
+        context.role_settings.clone(),
+        PathBuf::from(&context.default_workdir),
+    );
+    context
+        .activity
+        .lock()
+        .expect("activity runs poisoned")
+        .insert(run_id.clone(), activity.clone());
     thread::spawn(move || {
         let diagram_address: SocketAddr = "127.0.0.1:0".parse().expect("loopback address");
         let outcome = topology::run_topology(
             &bytecode,
             TopologyRunConfig {
+                activity: Some(activity),
                 ea_id: context.ea_id,
                 omar_dir: &context.omar_dir,
                 base_prefix: &context.session_prefix,

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -1265,6 +1265,7 @@ fn expired(invocation: &InvocationSpec, deadline: Duration) -> Result<BTreeMap<S
 }
 
 struct AgentReactionExecutor {
+    activity: Option<crate::activity::ActivityRun>,
     client: TmuxClient,
     team: String,
     registry: InvocationRegistry,
@@ -1277,6 +1278,23 @@ struct AgentReactionExecutor {
 
 impl ReactionExecutor for AgentReactionExecutor {
     fn invoke(&self, invocation: InvocationSpec) -> Result<BTreeMap<String, Value>> {
+        if let Some(activity) = &self.activity {
+            activity.start(&invocation.id, &invocation.reaction_id, &invocation.agent);
+        }
+        let id = invocation.id.clone();
+        let result = self.invoke_observed(invocation);
+        if let Some(activity) = &self.activity {
+            activity.finish(
+                &id,
+                result.is_ok(),
+                result.as_ref().map(|w| w.len()).unwrap_or(0),
+            );
+        }
+        result
+    }
+}
+impl AgentReactionExecutor {
+    fn invoke_observed(&self, invocation: InvocationSpec) -> Result<BTreeMap<String, Value>> {
         let invocation_id = invocation.id.clone();
         let rendered = render_prompt(&invocation.prompt, &invocation.trigger_values)?;
         let record = InvocationRecord {
@@ -1292,6 +1310,7 @@ impl ReactionExecutor for AgentReactionExecutor {
             completed: false,
         };
         let completion = self.registry.register(record)?;
+        let mut monitor_guard = None;
 
         // A web agent has no pane to deliver to: nothing was spawned for it,
         // and the registration above is the work item a panel asks for. What
@@ -1306,16 +1325,36 @@ impl ReactionExecutor for AgentReactionExecutor {
                 invocation.contract,
                 rendered
             );
+            let mut configured = false;
+            if let Some(activity) = &self.activity {
+                let mut monitor = crate::activity::InvocationMonitor::prepare(
+                    activity.clone(),
+                    &invocation_id,
+                    &self.client,
+                    &invocation.agent,
+                );
+                match monitor.deliver_configured(&message) {
+                    Ok(sent) => configured = sent,
+                    Err(_) => {
+                        activity.application(&invocation_id, "Requested settings could not be applied; invocation was not retried. Inspect terminal before retrying.");
+                        self.registry.remove(&invocation_id);
+                        bail!("requested role settings could not be applied; invocation was not retried");
+                    }
+                }
+                monitor_guard = Some(monitor.spawn());
+            }
             let session = self.client.session_for(&invocation.agent);
-            if let Err(error) = self
-                .client
-                .deliver_prompt_until(&session, &message, &DeliveryOptions::default(), &|| {
-                    self.registry.answered(&invocation_id)
-                })
-                .with_context(|| format!("failed to deliver {}", invocation.reaction_id))
-            {
-                self.registry.remove(&invocation_id);
-                return Err(error);
+            if !configured {
+                if let Err(error) = self
+                    .client
+                    .deliver_prompt_until(&session, &message, &DeliveryOptions::default(), &|| {
+                        self.registry.answered(&invocation_id)
+                    })
+                    .with_context(|| format!("failed to deliver {}", invocation.reaction_id))
+                {
+                    self.registry.remove(&invocation_id);
+                    return Err(error);
+                }
             }
         }
 
@@ -1328,11 +1367,22 @@ impl ReactionExecutor for AgentReactionExecutor {
             )),
         };
         self.registry.remove(&invocation_id);
+        let ended_at = crate::activity::now_ms();
+        drop(monitor_guard);
+        if let Some(activity) = &self.activity {
+            activity.finish_at(
+                &invocation_id,
+                result.is_ok(),
+                result.as_ref().map(|w| w.len()).unwrap_or(0),
+                ended_at,
+            );
+        }
         result
     }
 }
 
 pub struct TopologyRunConfig<'a> {
+    pub activity: Option<crate::activity::ActivityRun>,
     pub ea_id: crate::ea::EaId,
     pub omar_dir: &'a Path,
     pub base_prefix: &'a str,
@@ -1516,6 +1566,7 @@ pub fn run_topology(bytecode: &Bytecode, config: TopologyRunConfig<'_>) -> Resul
         }
     }
     let executor = AgentReactionExecutor {
+        activity: config.activity.clone(),
         client,
         team: state.team.clone(),
         registry: invocation_server.registry.clone(),
@@ -2529,7 +2580,7 @@ fn is_web_backend(backend: &str) -> bool {
     canonical_backend(backend) == "web"
 }
 
-fn canonical_backend(backend: &str) -> &str {
+pub(crate) fn canonical_backend(backend: &str) -> &str {
     match backend.to_ascii_lowercase().as_str() {
         "claude" | "claudecode" => "claude",
         "web" => "web",
@@ -3300,6 +3351,7 @@ mod tests {
         .unwrap();
         let state = verify(&bytecode).unwrap();
         let executor = AgentReactionExecutor {
+            activity: None,
             client: TmuxClient::new("omar-test"),
             team: state.team.clone(),
             registry: server.registry.clone(),
@@ -4413,5 +4465,91 @@ mod tests {
             LoopEnd::Stopped(_) => panic!("nothing requested a stop"),
         }
         assert_eq!(*executor.calls.lock().unwrap(), 2);
+    }
+    #[test]
+    fn activity_records_each_concurrent_completion_before_the_layer_closes() {
+        let dir = tempfile::tempdir().unwrap();
+        let activity = crate::activity::ActivityRun::new(
+            "run".into(),
+            "Team".into(),
+            BTreeMap::from([("one".into(), "web".into()), ("two".into(), "web".into())]),
+            crate::activity::RoleSettings::load(dir.path().join("roles.json")),
+            dir.path().into(),
+        );
+        let server = InvocationServer::start().unwrap();
+        let executor = AgentReactionExecutor {
+            activity: Some(activity.clone()),
+            client: TmuxClient::new("unused"),
+            team: "Team".into(),
+            registry: server.registry.clone(),
+            timeout: Duration::from_secs(10),
+            web: BTreeSet::from(["one".into(), "two".into()]),
+        };
+        thread::scope(|scope| {
+            let invoke = |id: &str, agent: &str| {
+                executor.invoke(InvocationSpec {
+                    id: id.into(),
+                    reaction_id: format!("r-{id}"),
+                    agent: agent.into(),
+                    trigger_values: BTreeMap::new(),
+                    allowed_effects: BTreeMap::new(),
+                    contract: String::new(),
+                    prompt: "fixture".into(),
+                    within: None,
+                })
+            };
+            let one = scope.spawn(move || invoke("a", "one"));
+            let two = scope.spawn(move || invoke("b", "two"));
+            for _ in 0..200 {
+                if server.registry.entries.lock().unwrap().len() == 2 {
+                    break;
+                }
+                thread::sleep(Duration::from_millis(5));
+            }
+            assert_eq!(server.registry.entries.lock().unwrap().len(), 2);
+            // Complete through the actual scoped invocation registry. Empty
+            // writes satisfy this fixture's empty contract.
+            server
+                .registry
+                .execute(
+                    "Team",
+                    "one",
+                    InvocationCommand::Complete(CompleteArgs {
+                        invocation_id: "a".into(),
+                    }),
+                )
+                .unwrap();
+            one.join().unwrap().unwrap();
+            let snapshot = activity.snapshot();
+            assert_eq!(
+                snapshot
+                    .invocations
+                    .iter()
+                    .find(|i| i.invocation_id == "a")
+                    .unwrap()
+                    .execution,
+                crate::activity::ActivityExecution::Completed
+            );
+            assert_eq!(
+                snapshot
+                    .invocations
+                    .iter()
+                    .find(|i| i.invocation_id == "b")
+                    .unwrap()
+                    .execution,
+                crate::activity::ActivityExecution::Running
+            );
+            server
+                .registry
+                .execute(
+                    "Team",
+                    "two",
+                    InvocationCommand::Complete(CompleteArgs {
+                        invocation_id: "b".into(),
+                    }),
+                )
+                .unwrap();
+            two.join().unwrap().unwrap();
+        });
     }
 }

--- a/web/app/agent-activity.tsx
+++ b/web/app/agent-activity.tsx
@@ -1,0 +1,202 @@
+"use client";
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
+import type { ActivitySnapshot, DiagramSnapshot, InvocationActivity, RoleSettingsSnapshot, RoleSelection } from "./lib/protocol-generated";
+import { normalizeRuntimeUrl } from "./lib/runtime-client";
+import { acceptActivity, activityState, elapsedLabel, noRecentActivity } from "./lib/activity";
+
+export function useActivity(serveUrl: string, runId: string | undefined) {
+  const [value, setValue] = useState<ActivitySnapshot | null>(null);
+  const [connection, setConnection] = useState<"connecting" | "connected" | "disconnected" | "unsupported">("connecting");
+  const [now, setNow] = useState(0);
+  const clock = useRef({ server: 0, local: 0 });
+  useEffect(() => {
+    if (!runId) return;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout>;
+    const controller = new AbortController();
+    const poll = async () => {
+      try {
+        const response = await fetch(`${normalizeRuntimeUrl(serveUrl)}/v1/runs/${encodeURIComponent(runId)}/activity`, { signal: AbortSignal.any([controller.signal, AbortSignal.timeout(8000)]) });
+        if (cancelled) return;
+        if (response.status === 404) { setConnection("unsupported"); return; }
+        if (!response.ok) throw new Error("Activity unavailable");
+        const incoming = await response.json() as ActivitySnapshot;
+        if (incoming.run_id !== runId || !Array.isArray(incoming.invocations) || !Number.isFinite(incoming.sequence) || !Number.isFinite(incoming.server_time)) throw new Error("Invalid activity snapshot");
+        if (cancelled) return;
+        clock.current = { server: incoming.server_time, local: performance.now() };
+        setNow(incoming.server_time);
+        setValue((current) => acceptActivity(current, incoming));
+        setConnection("connected");
+      } catch { if (!cancelled) setConnection("disconnected"); }
+      finally { if (!cancelled) timer = setTimeout(poll, 1000); }
+    };
+    void poll();
+    const tick = setInterval(() => { if (clock.current.server) setNow(clock.current.server + performance.now() - clock.current.local); }, 1000);
+    return () => { cancelled = true; clearTimeout(timer); clearInterval(tick); controller.abort(); };
+  }, [serveUrl, runId]);
+  return { snapshot: value?.run_id === runId ? value : null, connection, now };
+}
+
+const thresholdKey = "omar.inactivitySeconds.v1";
+function readThreshold() {
+  try { const value = Number(localStorage.getItem(thresholdKey)); return value >= 30 && value <= 3600 ? value : 120; }
+  catch { return 120; }
+}
+function subscribeThreshold(changed: () => void) {
+  window.addEventListener("storage", changed);
+  window.addEventListener("omar-inactivity", changed);
+  return () => { window.removeEventListener("storage", changed); window.removeEventListener("omar-inactivity", changed); };
+}
+export function useInactivityThreshold() {
+  const seconds = useSyncExternalStore(subscribeThreshold, readThreshold, () => 120);
+  return [seconds, (value: number) => {
+    try { localStorage.setItem(thresholdKey, String(Math.max(30, Math.min(3600, value)))); }
+    catch { /* A restricted browser cannot persist preferences. */ }
+    window.dispatchEvent(new Event("omar-inactivity"));
+  }] as const;
+}
+
+export function ActivitySummary({ snapshot, now, connected, seconds }: { snapshot: ActivitySnapshot | null; now: number; connected: boolean; seconds: number }) {
+  const active = snapshot?.invocations.filter((i) => i.execution === "running") ?? [];
+  return <div className="activity-summary" aria-label="Agent activity summary">
+    <span>{new Set(active.map((i) => i.agent_name)).size} active agents</span>
+    <span>{active.filter((i) => noRecentActivity(i, now, seconds, connected)).length} with no recent reported activity</span>
+    {!connected && snapshot ? <span>Activity connection lost · last known state</span> : null}
+  </div>;
+}
+
+export function RoleSettings({ serveUrl, snapshot }: { serveUrl: string; snapshot: DiagramSnapshot }) {
+  const [settings, setSettings] = useState<RoleSettingsSnapshot | null>(null);
+  const [error, setError] = useState("");
+  const [saving, setSaving] = useState<string | null>(null);
+  const [saved, setSaved] = useState<string | null>(null);
+  const reload = useCallback(async () => {
+    const response = await fetch(`${normalizeRuntimeUrl(serveUrl)}/v1/role-settings`);
+    if (!response.ok) throw new Error("Role settings unavailable from this runtime");
+    setSettings(await response.json());
+  }, [serveUrl]);
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`${normalizeRuntimeUrl(serveUrl)}/v1/role-settings`).then(async (response) => {
+      if (!response.ok) throw new Error("Role settings unavailable");
+      const value = await response.json();
+      if (!cancelled) setSettings(value);
+    }).catch(() => { if (!cancelled) setError("Role settings unavailable from this runtime"); });
+    return () => { cancelled = true; };
+  }, [serveUrl]);
+  const update = async (agent: string, backend: string, selection: RoleSelection) => {
+    setSaving(agent); setError(""); setSaved(null);
+    try {
+      const response = await fetch(`${normalizeRuntimeUrl(serveUrl)}/v1/role-settings`, {
+        method: "POST", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ team: snapshot.team, agent, backend, selection }),
+      });
+      if (!response.ok) { const body = await response.json(); throw new Error(body.error ?? "Settings could not be saved"); }
+      await reload(); setSaved(agent);
+    } catch (error) { setError(error instanceof Error ? error.message : "Settings could not be saved"); }
+    finally { setSaving(null); }
+  };
+  return <details className="role-settings">
+    <summary>Role model and effort settings · next invocation</summary>
+    <button type="button" className="secondary-button" onClick={() => void reload().catch(() => setError("Capabilities could not be refreshed"))}>Refresh supported models</button>
+    <p>Saved choices apply when each role’s next invocation starts. Active responses keep their settings.</p>
+    {!settings?.capabilities_available ? <p>Supported models unavailable. A connected Codex pane is needed to discover capabilities. Backend defaults apply.</p> : null}
+    <div className="role-settings-table">
+      {snapshot.agents.map((agent) => {
+        const backend = agent.backend.toLowerCase();
+        const selection = settings?.roles.find((r) => r.team === snapshot.team && r.agent === agent.name && r.backend === backend)?.selection ?? { model: null, effort: null };
+        const supported = backend === "codex" && settings?.capabilities_available;
+        const models = settings?.codex_models ?? [];
+        const model = models.find((m) => m.model === selection.model);
+        return <div className="role-settings-row" key={agent.id}>
+          <span>{agent.name}<small>{agent.backend}</small></span>
+          {supported ? <>
+            <label>Requested model<select aria-label={`${agent.name} requested model`} disabled={saving !== null} value={selection.model ?? ""} onChange={(e) => void update(agent.name, backend, { model: e.target.value || null, effort: null })}>
+              <option value="">Keep backend configuration</option>
+              {selection.model && !model ? <option value={selection.model}>{selection.model} · no longer available</option> : null}
+              {models.map((m) => <option key={m.model} value={m.model}>{m.name}</option>)}
+            </select></label>
+            <label>Requested effort<select aria-label={`${agent.name} requested effort`} disabled={!model || saving !== null} value={selection.effort ?? ""} onChange={(e) => void update(agent.name, backend, { ...selection, effort: e.target.value || null })}>
+              <option value="">Backend default</option>
+              {model?.efforts.map((effort) => <option key={effort}>{effort}</option>)}
+            </select></label>
+          </> : <span>Model and effort selection unsupported or unavailable</span>}
+          {saved === agent.name ? <small role="status">Saved for next invocation</small> : null}
+        </div>;
+      })}
+    </div>
+    {error ? <p role="alert">{error}</p> : null}
+  </details>;
+}
+
+function SettingsReadout({ i }: { i: InvocationActivity }) {
+  return <>
+    <dl className="activity-facts">
+      <div><dt>Backend</dt><dd>{i.backend}</dd></div>
+      <div><dt>Confirmed active model</dt><dd>{i.confirmed.model ?? "Not reported"}</dd></div>
+      <div><dt>Confirmed active effort</dt><dd>{i.confirmed.effort ?? "Not reported"}</dd></div>
+      <div><dt>Requested for this invocation</dt><dd>{i.requested.model ?? "Keep backend configuration"} · {i.requested.effort ?? "Default effort"}</dd></div>
+      <div><dt>Backend thread configuration</dt><dd>{i.reported_thread_settings.model ?? "Not reported"} · {i.reported_thread_settings.effort ?? "Not reported"}</dd></div>
+    </dl>
+    <p className="activity-note">{i.settings_application}. Thread configuration does not confirm execution settings.</p>
+  </>;
+}
+
+export function AgentActivity({ agent, activity, connection, now, seconds, onThreshold, onOpenTerminal, onClose }: {
+  agent: string; activity: ActivitySnapshot | null; connection: string; now: number; seconds: number;
+  onThreshold: (seconds: number) => void; onOpenTerminal?: () => void; onClose: () => void;
+}) {
+  const invocations = activity?.invocations.filter((i) => i.agent_name === agent).slice().reverse() ?? [];
+  const [chosen, setChosen] = useState<string | null>(null);
+  const i = invocations.find((i) => i.invocation_id === chosen) ?? invocations[0];
+  const close = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    close.current?.focus();
+    const escape = (event: KeyboardEvent) => { if (event.key === "Escape") onClose(); };
+    window.addEventListener("keydown", escape);
+    return () => window.removeEventListener("keydown", escape);
+  }, [onClose]);
+  return <aside className="agent-activity" aria-label={`${agent} activity`}>
+    <header><div><span className="eyebrow">AGENT ACTIVITY</span><h2>{agent}</h2></div><button type="button" ref={close} className="secondary-button" onClick={onClose}>Close</button></header>
+    {onOpenTerminal ? <button type="button" className="secondary-button" onClick={onOpenTerminal}>Open agent terminal</button> : null}
+    <label className="inactivity-setting">Inactivity notice after
+      <select aria-label="Inactivity notice threshold" value={seconds} onChange={(e) => onThreshold(Number(e.target.value))}>
+        {[30, 60, 120, 300, 600, 1800, 3600].map((s) => <option key={s} value={s}>{s < 60 ? `${s} seconds` : `${s / 60} minutes`}</option>)}
+      </select>
+    </label>
+    <p className="activity-note">This notice does not interrupt work or diagnose a stall.</p>
+    {connection === "disconnected" ? <p role="status">Activity connection lost · showing last known observations.</p> : null}
+    {!i ? <p>Activity details unavailable. {connection === "connecting" ? "Connecting to runtime…" : "No invocation activity has been reported for this agent."}</p> : <>
+      <label>Invocation<select aria-label="Invocation history" value={i.invocation_id} onChange={(e) => setChosen(e.target.value)}>
+        {invocations.map((i) => <option key={i.invocation_id} value={i.invocation_id}>{i.reaction_id} · {new Date(i.started_at).toLocaleTimeString()}</option>)}
+      </select></label>
+      <div className="activity-state"><strong>{activityState(i)}</strong><span>Elapsed {elapsedLabel(i.started_at, i.finished_at ?? now)}</span></div>
+      <SettingsReadout i={i} />
+      {i.connection === "disconnected" ? <p role="status">Agent monitoring connection lost. Execution status is the runtime’s last report.</p> : null}
+      {i.connection === "unsupported" ? <p>Activity details unavailable for this backend connection.</p> : null}
+      {i.connection === "connecting" ? <p>Connecting to agent activity…</p> : null}
+      {noRecentActivity(i, now, seconds, connection === "connected") ? <p className="inactivity-notice">No reported activity for {elapsedLabel(i.last_activity_at, now)}. The agent has not reported another action. It may still be generating a response.</p> : null}
+      <h3>Current observed activity</h3>
+      {i.active_tools.length ? <ul>{i.active_tools.map((tool) => <li key={tool.id}>{tool.summary} · {tool.started_at === null ? `observed ${elapsedLabel(tool.observed_at, now)} ago; start time unavailable` : elapsedLabel(tool.started_at, now)}</li>)}</ul> : <p>{i.execution === "running" ? "No tool currently reported" : "Invocation ended"}</p>}
+      <p>Latest activity: {i.events.at(-1)?.summary ?? "Not reported"}<br />{elapsedLabel(i.last_activity_at, i.finished_at ?? now)} {i.finished_at ? "before invocation ended" : "ago"}</p>
+      <details open><summary>View activity · {i.events.length} recent events</summary>
+        <ol className="activity-events">{i.events.map((event) => <li key={event.id}>
+          <time dateTime={new Date(event.at).toISOString()}>{new Date(event.at).toLocaleTimeString()}</time>
+          <span>{event.summary}{event.exit_code !== null ? ` · exit code ${event.exit_code}` : ""}
+            {event.time_source === "recovered" ? <small>Recovered after connect; observation time, exact event time unavailable</small> : null}
+          </span>
+        </li>)}</ol>
+      </details>
+      <details open><summary>View changes · {i.artifacts.length} attributed files</summary>
+        <p className="activity-note">Only successful file-edit events attributable to this agent are listed. Shell and shared workspace changes may be missing. Changed does not mean verified.</p>
+        {i.artifacts.length === 0 ? <p>No attributable file changes reported.</p> : i.artifacts.map((file) => <details className="artifact" key={file.id}>
+          <summary>{file.change} · {file.path}</summary>
+          <p>{new Date(file.observed_at).toLocaleTimeString()} · {file.verification}</p>
+          {file.diff ? <pre aria-label={`${file.path} diff`}>{file.diff}</pre> : <p>Diff unavailable</p>}
+          {file.diff_truncated ? <p>Diff truncated to 16 KiB.</p> : null}
+          <p className="activity-note">Sensitive files are omitted; sensitive lines are redacted.</p>
+        </details>)}
+      </details>
+    </>}
+  </aside>;
+}

--- a/web/app/diagram/diagram-canvas.tsx
+++ b/web/app/diagram/diagram-canvas.tsx
@@ -9,6 +9,8 @@ import {
   useRef,
   useState,
 } from "react";
+import type { ActivitySnapshot } from "../lib/protocol-generated";
+import { activityState, elapsedLabel, latestInvocation } from "../lib/activity";
 import { formatDuration, webAgents, type DiagramSnapshot } from "../lib/protocol";
 
 /**
@@ -452,6 +454,7 @@ function reactionWidth(labels: ReactionLabels, within: number | null): number {
   const widest = Math.max(
     textWidth(labels.name, 6.9),
     textWidth(labels.meta, 5.2),
+    textWidth("Waiting for dependencies", 5.2),
   );
   // A deadline is drawn between the text and the point, so the node has to be
   // wider for it rather than the stopwatch sitting on top of the name.
@@ -1115,6 +1118,8 @@ export function componentName(id: string): string {
 
 export function DiagramCanvas({
   snapshot,
+  activity,
+  activityNow = 0,
   selection = [],
   onToggleComponent,
   onOpenTerminal,
@@ -1122,6 +1127,8 @@ export function DiagramCanvas({
   highlight,
 }: {
   snapshot: DiagramSnapshot;
+  activity?: ActivitySnapshot | null;
+  activityNow?: number;
   selection?: string[];
   onToggleComponent?: (component: string) => void;
   /** Given only while agents are actually running and can be attached to. */
@@ -1533,7 +1540,7 @@ export function DiagramCanvas({
                   key={reaction.id}
                   {...selectable(
                     reaction.id,
-                    `omar-reaction ${reaction.status}${reaction.web ? " web" : ""}`,
+                    `omar-reaction ${latestInvocation(activity ?? null, reaction.id)?.execution ?? reaction.status}${reaction.web ? " web" : ""}`,
                   )}
                   onDoubleClick={(event) => {
                     // The canvas resets the view on double click; a reaction
@@ -1579,7 +1586,11 @@ export function DiagramCanvas({
                     x={REACTION_TEXT_X}
                     y={reaction.box.height / 2 + 12}
                   >
-                    {reaction.meta}
+                    {(() => {
+                      const invocation = latestInvocation(activity ?? null, reaction.id);
+                      return invocation ? `${activityState(invocation)} · ${elapsedLabel(invocation.started_at, invocation.finished_at ?? activityNow)}`
+                        : reaction.status === "idle" && snapshot.status !== "ready" ? (snapshot.status === "running" ? "Waiting for dependencies" : "Not invoked") : reaction.meta;
+                    })()}
                   </text>
                   {/* A deadline the program set for itself. A stopwatch rather
                       than a clock: a timer fires on its own, this counts down

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -2236,3 +2236,35 @@ h2 {
   color: #e0777f;
   font-size: 10.5px;
 }
+
+/* Evidence-based agent activity; topology remains a compact overview. */
+.activity-summary { display: flex; flex-wrap: wrap; gap: 8px 20px; padding: 10px 20px; border-bottom: 1px solid var(--line, #263335); font-size: 12px; }
+.role-settings { padding: 12px 20px; border-bottom: 1px solid var(--line, #263335); font-size: 12px; }
+.role-settings summary, .agent-activity summary { cursor: pointer; padding: 6px 0; }
+.role-settings-table { display: grid; gap: 10px; }
+.role-settings-row { display: flex; flex-wrap: wrap; gap: 12px; align-items: end; }
+.role-settings-row > span:first-child { min-width: 150px; }
+.role-settings-row label, .agent-activity label { display: grid; gap: 5px; }
+.role-settings small, .activity-events small { display: block; opacity: .65; }
+.role-settings select, .agent-activity select { color: inherit; background: var(--panel, #18201e); border: 1px solid #46534e; border-radius: 4px; padding: 6px; max-width: 100%; }
+.agent-activity { position: fixed; z-index: 30; right: 0; top: 0; bottom: 0; width: min(500px, 100vw); overflow-y: auto; box-sizing: border-box; padding: 24px; color: #e6eae6; background: #111015; border-left: 1px solid #45404e; box-shadow: -12px 0 40px #0005; font-size: 13px; }
+.agent-activity header, .activity-state { display: flex; justify-content: space-between; align-items: center; gap: 16px; }
+.agent-activity h2 { overflow-wrap: anywhere; }
+.agent-activity h3 { margin-top: 24px; font-size: 13px; }
+.agent-activity > label, .activity-state { margin-top: 18px; }
+.activity-facts { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.activity-facts dt { color: #aaa4b6; font-size: 11px; margin-bottom: 4px; }
+.activity-facts dd { margin: 0; overflow-wrap: anywhere; }
+.activity-note { color: #aaa4b6; font-size: 11px; line-height: 1.6; }
+.inactivity-notice { padding: 12px; background: #25222d; border-left: 3px solid #b6adc7; line-height: 1.6; }
+.activity-events { list-style: none; padding: 0; }
+.activity-events li { display: grid; grid-template-columns: 75px 1fr; gap: 12px; border-top: 1px solid #35313c; padding: 10px 0; }
+.activity-events time { color: #aaa4b6; font-size: 11px; }
+.artifact { overflow-wrap: anywhere; border-top: 1px solid #35313c; padding: 8px 0; }
+.artifact pre { overflow: auto; max-height: 350px; font-size: 11px; padding: 12px; background: #09080c; white-space: pre; }
+.agent-activity-button { margin-left: 8px; }
+@media (max-width: 600px) { .agent-activity { padding: 16px; } .activity-facts { grid-template-columns: 1fr; } }
+
+.diagram-panel .activity-summary, .diagram-panel .role-settings { color: #34313d; background: #f8f7fa; border-color: #d9d5df; flex-shrink: 0; }
+.diagram-panel .role-settings[open] { max-height: 220px; overflow-y: auto; }
+.diagram-panel .activity-summary select, .diagram-panel .role-settings select { color: #34313d; background: white; border: 1px solid #b9b4c3; border-radius: 4px; padding: 5px; }

--- a/web/app/lib/activity.ts
+++ b/web/app/lib/activity.ts
@@ -1,0 +1,27 @@
+import type { ActivitySnapshot, InvocationActivity } from "./protocol-generated.ts";
+
+export function elapsedLabel(start: number, end: number): string {
+  const seconds = Math.max(0, Math.floor((end - start) / 1000));
+  return seconds < 60 ? `${seconds}s` : `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+}
+
+/** An open tool remains observed work even when it produces no new output. */
+export function noRecentActivity(i: InvocationActivity, now: number, thresholdSeconds: number, connected = true): boolean {
+  return connected && i.execution === "running" && i.connection === "connected" &&
+    i.active_tools.length === 0 && now - i.last_activity_at >= thresholdSeconds * 1000;
+}
+export function activityState(i: InvocationActivity): string {
+  if (i.execution === "completed") return "Completed";
+  if (i.execution === "failed") return "Failed";
+  return i.active_tools.length ? "Running a tool" : "Running";
+}
+export function latestInvocation(snapshot: ActivitySnapshot | null, reactionId: string): InvocationActivity | undefined {
+  // Protocol reaction IDs carry a display prefix; runtime IDs do not.
+  const id = reactionId.replace(/^reaction::/, "");
+  return snapshot?.invocations.filter((i) => i.reaction_id === id || i.reaction_id === reactionId)
+    .reduce<InvocationActivity | undefined>((latest, i) => !latest || i.started_at >= latest.started_at ? i : latest, undefined);
+}
+export function acceptActivity(previous: ActivitySnapshot | null, incoming: ActivitySnapshot): ActivitySnapshot {
+  if (!previous || previous.run_id !== incoming.run_id) return incoming;
+  return incoming.sequence >= previous.sequence ? incoming : previous;
+}

--- a/web/app/lib/protocol-generated.ts
+++ b/web/app/lib/protocol-generated.ts
@@ -4,6 +4,14 @@
 // file makes the client disagree with the daemon, which is the failure the
 // generator exists to make impossible.
 
+/** Runtime invocation outcome, independent of monitoring. */
+export const ACTIVITY_EXECUTIONS = ["running", "completed", "failed"] as const;
+export type ActivityExecution = (typeof ACTIVITY_EXECUTIONS)[number];
+
+/** Availability of the backend monitoring connection. */
+export const ACTIVITY_CONNECTIONS = ["connecting", "connected", "disconnected", "unsupported"] as const;
+export type ActivityConnection = (typeof ACTIVITY_CONNECTIONS)[number];
+
 /** Every status `omar serve` can report a run in. */
 export const RUN_STATUSES = ["starting", "running", "stopping", "completed", "stopped", "failed"] as const;
 export type RunStatus = (typeof RUN_STATUSES)[number];
@@ -31,6 +39,24 @@ export type DiagramEventKind = (typeof DIAGRAM_EVENT_KINDS)[number];
 /** Who spoke. */
 export const CHAT_ROLES = ["operator", "assistant"] as const;
 export type ChatRole = (typeof CHAT_ROLES)[number];
+
+export type ActivityEvent = { id: string, at: number, time_source: string, kind: string, summary: string, tool_id: string | null, exit_code: number | null, };
+
+export type ObservedTool = { id: string, summary: string, started_at: number | null, observed_at: number, };
+
+export type ChangedArtifact = { id: string, path: string, change: string, observed_at: number, diff: string | null, diff_truncated: boolean, verification: string, };
+
+export type RoleSelection = { model: string | null, effort: string | null, };
+
+export type InvocationActivity = { invocation_id: string, reaction_id: string, agent_name: string, backend: string, started_at: number, finished_at: number | null, execution: ActivityExecution, connection: ActivityConnection, last_activity_at: number, events: Array<ActivityEvent>, active_tools: Array<ObservedTool>, artifacts: Array<ChangedArtifact>, requested: RoleSelection, confirmed: RoleSelection, reported_thread_settings: RoleSelection, settings_application: string, };
+
+export type ActivitySnapshot = { run_id: string, sequence: number, server_time: number, invocations: Array<InvocationActivity>, };
+
+export type SupportedModel = { model: string, name: string, efforts: Array<string>, default_effort: string | null, };
+
+export type SavedRoleSettings = { team: string, agent: string, backend: string, selection: RoleSelection, };
+
+export type RoleSettingsSnapshot = { roles: Array<SavedRoleSettings>, codex_models: Array<SupportedModel>, capabilities_available: boolean, };
 
 export type DiagramTag = { timestamp: number, microstep: number, };
 

--- a/web/app/studio.tsx
+++ b/web/app/studio.tsx
@@ -2,6 +2,7 @@
 
 import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChatMessage as ChatMessageView } from "./chat-message";
+import { AgentActivity, ActivitySummary, RoleSettings, useActivity, useInactivityThreshold } from "./agent-activity";
 import { AgentTerminal } from "./agent-terminal";
 import { Timeline } from "./timeline";
 import { BackendMenu } from "./backend-menu";
@@ -18,6 +19,7 @@ import {
 import { reviewProgram, reviewWorkflow } from "./lib/fixtures";
 import {
   applyDiagramEvent,
+  assertDiagramSnapshot,
   formatDuration,
   isRunFinished,
   openInputs,
@@ -137,6 +139,9 @@ export function Studio({
   /** Diagram components the operator has highlighted for the next message. */
   const [selection, setSelection] = useState<string[]>([]);
   /** The agent whose terminal is open, if any. */
+  const [activityAgent, setActivityAgent] = useState<string | null>(null);
+  const activity = useActivity(serveUrl, run?.run_id);
+  const [inactivitySeconds, setInactivitySeconds] = useInactivityThreshold();
   const [terminalAgent, setTerminalAgent] = useState<string | null>(null);
   /** The web agent whose port panel is open. A program may declare several,
       each with its own ports and prompts, so this names one rather than
@@ -174,6 +179,19 @@ export function Studio({
   const checkTokenRef = useRef(0);
   // Read by the check, which must not re-run every time a run advances.
   const runRef = useRef<RunRecord | null>(null);
+  const restoration = useRef<{ run_id: string; snapshot: DiagramSnapshot; sequence: number } | null>(null);
+  const replayedProposal = useRef(0);
+  const resumeKey = `omar.activity.run:${serveUrl}`;
+  useEffect(() => {
+    if (isDemo) return;
+    try {
+      const saved = JSON.parse(sessionStorage.getItem(resumeKey) ?? "null");
+      if (saved && typeof saved.run_id === "string") {
+        restoration.current = { ...saved, snapshot: assertDiagramSnapshot(saved.snapshot) };
+        replayedProposal.current = saved.sequence ?? 0;
+      }
+    } catch { /* Storage may be disabled or belong to an older client. */ }
+  }, [isDemo, resumeKey]);
   useEffect(() => {
     runRef.current = run;
   }, [run]);
@@ -255,6 +273,7 @@ export function Studio({
           }
           return;
         }
+        if (message.sequence <= replayedProposal.current) return;
         setConfirming(false);
         setDesign(message.design);
         setSource(message.design.program);
@@ -432,6 +451,36 @@ export function Studio({
     },
     [serveUrl, loadPanel],
   );
+
+  // A browser reload reattaches to the exact selected run. Only topology
+  // structure/status is cached; activity and outcomes are re-fetched from the
+  // daemon. This is not saved chat history.
+  useEffect(() => {
+    if (isDemo) return;
+    const saved = restoration.current;
+    if (!saved) return;
+    let cancelled = false;
+    void fetchRun(serveUrl, saved.run_id).then((record) => {
+      if (cancelled || runRef.current) return;
+      runRef.current = record;
+      setRun(record);
+      setSnapshot(saved.snapshot);
+      setPhase(isRunFinished(record.status) ? record.status === "failed" ? "failed" : "finished" : "observing");
+      setInspectorWidth(0);
+      setBuilderWidth(DEFAULT_BUILDER);
+      if (!isRunFinished(record.status)) observe(record);
+    }).catch(() => { /* Daemon restart has no resumable run; no outcome inferred. */ });
+    return () => { cancelled = true; };
+  }, [isDemo, serveUrl, observe]);
+  useEffect(() => {
+    if (isDemo || !run || !snapshot || snapshot.team !== run.team) return;
+    try {
+      sessionStorage.setItem(resumeKey, JSON.stringify({ run_id: run.run_id,
+        sequence: Math.max(replayedProposal.current, ...messages.map((m) => m.sequence)),
+        snapshot: { ...snapshot, ports: snapshot.ports.map((port) => ({ ...port, value: null })) },
+      }));
+    } catch { /* Quota/disabled storage must not affect execution. */ }
+  }, [isDemo, run, snapshot, messages, resumeKey]);
 
   async function confirmDesign() {
     if (!design || phase !== "review") return;
@@ -853,7 +902,22 @@ export function Studio({
             </div>
             ) : null}
           </div>
+          {run ? <ActivitySummary snapshot={activity.snapshot} now={activity.now} connected={activity.connection === "connected"} seconds={inactivitySeconds} /> : null}
+          {!isDemo ? <RoleSettings serveUrl={serveUrl} snapshot={snapshot} /> : null}
+          <div className="activity-summary" aria-label="Inspect agents">
+            <label>Inspect agent <select aria-label="Inspect agent" value={activityAgent ?? ""} onChange={(event) => setActivityAgent(event.target.value || null)}>
+              <option value="">Choose an agent…</option>
+              {snapshot.agents.map((agent) => <option key={agent.id} value={agent.name}>{agent.name}</option>)}
+            </select></label>
+            {selection.slice(-1).flatMap((name) => {
+              const reaction = snapshot.reactions.find((r) => r.id === `reaction::${name}`);
+              const agent = snapshot.agents.find((a) => a.id === reaction?.agent || a.name === name);
+              return agent ? [<button key={agent.id} className="secondary-button" type="button" onClick={() => setActivityAgent(agent.name)}>View {agent.name} activity</button>] : [];
+            })}
+          </div>
           <DiagramCanvas
+            activity={activity.snapshot}
+            activityNow={activity.now}
             snapshot={snapshot}
             selection={selection}
             onToggleComponent={toggleComponent}
@@ -957,6 +1021,10 @@ export function Studio({
         ) : null}
       </section>
 
+      {activityAgent ? <AgentActivity key={activityAgent} agent={activityAgent} activity={activity.snapshot} connection={activity.connection}
+        now={activity.now} seconds={inactivitySeconds} onThreshold={setInactivitySeconds}
+        onOpenTerminal={canRun && run && snapshot?.agents.find((a) => a.name === activityAgent)?.backend.toLowerCase() !== "web" ? () => setTerminalAgent(activityAgent) : undefined}
+        onClose={() => setActivityAgent(null)} /> : null}
       {panelAgent && snapshot ? (
         <PortPanel
           agent={panelAgent}

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,7 @@
     "build": "WRANGLER_LOG_PATH=.wrangler/wrangler.log vinext build",
     "build:spa": "vite build --config vite.spa.config.ts && node build/compress-spa.mjs",
     "start": "WRANGLER_LOG_PATH=.wrangler/wrangler.log vinext start",
-    "test": "npm run build && node --test --experimental-strip-types --disable-warning=ExperimentalWarning tests/rendered-html.test.mjs tests/protocol-contract.test.mjs",
+    "test": "npm run build && node --test --experimental-strip-types --disable-warning=ExperimentalWarning tests/rendered-html.test.mjs tests/protocol-contract.test.mjs tests/activity.test.mjs",
     "lint": "eslint . --ignore-pattern dist --ignore-pattern .next",
     "test:e2e": "playwright test",
     "test:conformance": "node --test tests/conformance.test.mjs",

--- a/web/tests/activity.test.mjs
+++ b/web/tests/activity.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { acceptActivity, activityState, elapsedLabel, latestInvocation, noRecentActivity } from "../app/lib/activity.ts";
+
+const invocation = (overrides = {}) => ({ invocation_id: "a", reaction_id: "flow.reaction.0", agent_name: "flow.one", execution: "running", connection: "connected", started_at: 1000, last_activity_at: 2000, finished_at: null, active_tools: [], ...overrides });
+
+test("long tools remain observed work; inactivity and connection loss are distinct", () => {
+  const quiet = invocation();
+  assert.equal(noRecentActivity(quiet, 122000, 120), true);
+  assert.equal(noRecentActivity(quiet, 122000, 300), false);
+  for (const connection of ["unsupported", "disconnected", "connecting"]) assert.equal(noRecentActivity(invocation({connection}), 999999, 120), false);
+  assert.equal(noRecentActivity(quiet, 999999, 120, false), false);
+  assert.equal(noRecentActivity(invocation({ active_tools: [{id: "tool", started_at: 2000}] }), 999999, 120), false);
+  assert.equal(activityState(invocation({ active_tools: [{id: "tool"}] })), "Running a tool");
+  assert.equal(activityState(invocation({execution: "completed", active_tools: [{id: "old"}]})), "Completed");
+});
+test("invocation clock freezes on completion and never uses total workflow time", () => {
+  assert.equal(elapsedLabel(1000, 273000), "4m 32s");
+  assert.equal(elapsedLabel(273000, 1000), "0s");
+  const done = invocation({ finished_at: 9000, execution: "completed" });
+  assert.equal(elapsedLabel(done.started_at, done.finished_at ?? 999999), "8s");
+  assert.equal(noRecentActivity(done, 999999, 30), false);
+});
+test("reload snapshots and delayed polls preserve concurrent invocation identity", () => {
+  const a = invocation(); const b = invocation({invocation_id: "b", agent_name: "flow.two", reaction_id: "flow.reaction.1", started_at: 4000});
+  const snapshot = {run_id:"run", sequence:2, invocations:[a,b]};
+  assert.equal(latestInvocation(snapshot, "reaction::flow.reaction.0"), a);
+  assert.equal(latestInvocation(snapshot, "reaction::flow.reaction.1"), b);
+  assert.equal(acceptActivity(snapshot, {run_id:"run", sequence:1, invocations:[]}), snapshot);
+  assert.equal(acceptActivity(null, snapshot), snapshot);
+  assert.equal(acceptActivity(snapshot, {run_id:"new",sequence:0,invocations:[]}).run_id, "new");
+});

--- a/web/tests/conformance.test.mjs
+++ b/web/tests/conformance.test.mjs
@@ -469,6 +469,19 @@ describe(
 
       assert.equal(latest.status, "completed", JSON.stringify(latest));
       assert.equal(latest.error, null);
+      const activity = await (await fetch(`${real.url}/v1/runs/${record.run_id}/activity`)).json();
+      assert.equal(activity.run_id, record.run_id);
+      assert.equal(activity.invocations.length, 2);
+      for (const invocation of activity.invocations) {
+        assert.equal(invocation.execution, "completed");
+        assert.equal(invocation.connection, "unsupported", "a stub has runtime timing, no invented tool telemetry");
+        assert.ok(invocation.finished_at >= invocation.started_at);
+        assert.deepEqual(invocation.artifacts, []);
+        assert.equal(invocation.events[0].kind, "invocation_started");
+        assert.equal(invocation.events.at(-1).kind, "invocation_ended");
+      }
+      const reloaded = await (await fetch(`${real.url}/v1/runs/${record.run_id}/activity`)).json();
+      assert.deepEqual(reloaded.invocations, activity.invocations, "completion stays readable after diagram server exits");
     });
   },
 );

--- a/web/tests/e2e/activity.spec.ts
+++ b/web/tests/e2e/activity.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "@playwright/test";
+import { readFile } from "node:fs/promises";
+import { FAKE_SERVE_PORT, FAKE_SERVE_URL } from "../../playwright.config";
+import { startFakeServe } from "../fake-serve.mjs";
+import type { ActivitySnapshot, InvocationActivity, SavedRoleSettings } from "../../app/lib/protocol-generated";
+
+// Explicit simulation: these app-server lifecycle cases do not invoke a model.
+// Rust Unix-socket tests check the projection; conformance tests check real Omar.
+test("activity fixtures: concurrent agents, long tool, settings, diff, reconnect, reload, completion", async ({ page, request }) => {
+  const fake = await startFakeServe({ port: FAKE_SERVE_PORT });
+  try {
+    const program = await readFile(new URL("../fixtures/review-flow.omar", import.meta.url), "utf8");
+    const response = await request.post(`${FAKE_SERVE_URL}/v1/runs`, { data: { program, inputs: {"flow.request":"fixture"} } });
+    const record = await response.json();
+    const diagram = JSON.parse(await readFile(new URL("../fixtures/diagram-snapshot.v1.json", import.meta.url), "utf8"));
+    diagram.status = "running";
+    const start = Date.now() - 240000;
+    const invocation = (id: string, agent: string, reaction: string): InvocationActivity => ({
+      invocation_id:id, agent_name:agent, reaction_id:reaction, backend:"codex", started_at:start, finished_at:null,
+      execution:"running", connection:"connected", last_activity_at:start + 1000,
+      requested:{model:"fixture-model", effort:"medium"}, confirmed:{model:null, effort:null}, reported_thread_settings:{model:"fixture-model",effort:"medium"},
+      settings_application:"Fixture settings accepted by turn/start", active_tools:[], artifacts:[],
+      events:[{id:`${id}:start`,at:start,time_source:"runtime",kind:"invocation_started",summary:"Fixture invocation started",tool_id:null,exit_code:null}],
+    });
+    const first = invocation("first", "flow.planner", "flow.reaction.0");
+    first.active_tools = [{id:"long",summary:"Fixture validation command",started_at:start + 1000,observed_at:start+1000}];
+    first.artifacts = [{id:"file",path:"API_CONTRACT.md",change:"created",observed_at:start+1000,diff:"+ fixture API contract\n",diff_truncated:false,verification:"Not verified"}];
+    const second = invocation("second", "flow.reviewer", "flow.reaction.1");
+    let activity: ActivitySnapshot = {run_id:record.run_id, sequence:1,server_time:Date.now(),invocations:[first,second]};
+    let disconnected = false;
+    let roles: SavedRoleSettings[] = [];
+    await page.route(`${FAKE_SERVE_URL}/v1/runs/*/activity`, async (route) => {
+      if (disconnected) return route.abort();
+      await route.fulfill({json:{...activity,server_time:Date.now()}});
+    });
+    await page.route(`${FAKE_SERVE_URL}/v1/role-settings`, async (route) => {
+      if (route.request().method() === "POST") { roles = [route.request().postDataJSON()]; await route.fulfill({json:{saved:true,applies_to:"next_invocation"}}); }
+      else await route.fulfill({json:{roles,capabilities_available:true,codex_models:[{model:"fixture-model",name:"Fixture model",efforts:["medium","high"],default_effort:"medium"}]}});
+    });
+    // Keep fake runtime in flight; timeline events are not the fixture's source.
+    await page.route(`${FAKE_SERVE_URL}/v1/events`, (route) => route.fulfill({ contentType:"text/event-stream", body:": fixture connection\n\n" }));
+    await page.route(`${FAKE_SERVE_URL}/v1/diagram`, (route) => route.fulfill({json:diagram}));
+    await page.addInitScript(({key, value}) => sessionStorage.setItem(key, JSON.stringify(value)), {
+      key:`omar.activity.run:${FAKE_SERVE_URL}`, value:{run_id:record.run_id,snapshot:diagram,sequence:0},
+    });
+    const errors: string[] = [];
+    page.on("pageerror", (error) => errors.push(error.message));
+    await page.goto("/");
+    await expect(page).toHaveTitle("OMAR Mission Control");
+    await expect(page.getByLabel("Agent activity summary")).toContainText("2 active agents");
+    await expect(page.getByLabel("Agent activity summary")).toContainText("1 with no recent");
+    await page.getByLabel("Inspect agent", {exact:true}).selectOption("flow.planner");
+    const panel = page.getByLabel("flow.planner activity", {exact:true});
+    await expect(panel).toContainText("Running a tool");
+    await expect(panel).toContainText("Fixture validation command");
+    await expect(panel).not.toContainText("No reported activity for");
+    await expect(panel).toContainText("Not reported");
+    await panel.getByText("created · API_CONTRACT.md", {exact:true}).click();
+    await expect(panel.getByLabel("API_CONTRACT.md diff")).toContainText("+ fixture API contract");
+    await expect(panel).toContainText("Not verified");
+    await panel.getByRole("button", {name:"Close",exact:true}).click();
+    await page.getByText("Role model and effort settings · next invocation",{exact:true}).click();
+    await page.getByLabel("flow.planner requested model").selectOption("fixture-model");
+    await page.getByLabel("flow.planner requested effort").selectOption("high");
+    await expect(page.getByRole("status")).toContainText("Saved for next invocation");
+    expect(roles[0].selection.effort).toBe("high");
+    await page.getByLabel("Inspect agent",{exact:true}).selectOption("flow.reviewer");
+    const reviewer = page.getByLabel("flow.reviewer activity",{exact:true});
+    await expect(reviewer).toContainText("No reported activity for");
+    await reviewer.getByLabel("Inactivity notice threshold").selectOption("600");
+    await expect(reviewer).not.toContainText("No reported activity for");
+    await reviewer.getByLabel("Inactivity notice threshold").selectOption("120");
+    disconnected = true;
+    await expect(reviewer).toContainText("Activity connection lost");
+    await expect(reviewer).not.toContainText("No reported activity for");
+    disconnected = false;
+    activity = {...activity, sequence:2};
+    await expect(reviewer).not.toContainText("Activity connection lost");
+    await expect(reviewer).toContainText("No reported activity for");
+    await page.reload();
+    await expect(page.getByLabel("Agent activity summary")).toContainText("2 active agents");
+    await page.getByLabel("Inspect agent",{exact:true}).selectOption("flow.planner");
+    await expect(panel).toContainText("Running a tool");
+    await expect(panel).toContainText("medium"); // Requested at start is unchanged.
+    activity = {...activity, sequence:3, invocations:[{...first, execution:"completed",finished_at:start+200000,active_tools:[]},second]};
+    await expect(panel).toContainText("Completed");
+    await expect(panel).toContainText("Elapsed 3m 20s");
+    await expect(page.getByLabel("Agent activity summary")).toContainText("1 active agents");
+    expect(errors).toEqual([]);
+    await page.screenshot({path:"/tmp/omar-progress-desktop.png"});
+    await page.setViewportSize({width:390,height:844});
+    await expect(panel).toBeVisible();
+    expect((await panel.boundingBox())!.width).toBeLessThanOrEqual(390);
+    await page.screenshot({path:"/tmp/omar-progress-mobile.png"});
+  } finally { await fake.close(); }
+});


### PR DESCRIPTION
When several reactions are running, a single “Running” label hides whether an agent has started a tool, finished its invocation, stopped reporting activity, or lost its monitoring connection. This adds evidence-based activity and invocation timing to Omar’s web UI, with inspectable changes and explicit next-invocation model/effort settings.

## Behavior

- Compact topology state and invocation elapsed time; selected-agent activity panel with current tools, latest observation, recent starts/finishes/errors, command exit codes, and attributable file-edit diffs.
- Independent runtime invocation tracking, including completion before other agents in the same layer finish. Sequenced snapshots remain available after the diagram server exits and restore on page reload/reconnect.
- Configurable inactivity notice (default two minutes) that never diagnoses a stall or interrupts work. Open long-running tools suppress the notice; connection loss is separate.
- Codex capabilities from live `model/list`; persisted per-role requests are snapshotted at invocation start. Explicit settings use validated `turn/start` overrides for the next invocation without changing approval policy or restarting agents. Accepted requests, reported thread configuration, and confirmed execution settings remain distinct.
- Scoped successful file-change events only; changed files are not labeled verified. No raw arguments, commands, output, private reasoning, or filesystem-watcher attribution. Sensitive files/lines/key blocks are omitted or redacted; diffs are bounded.

## Support and limits

All backends have real runtime invocation timing. Detailed activity uses a pane’s unambiguous Codex app-server thread, matches the delivered invocation marker/returned turn ID, and projects structured events or recovered history. Other backends display “Activity details unavailable” with terminal access.

A live isolated smoke test against installed Codex 0.153.4 confirmed Unix WebSocket transport, model/effort discovery and metadata reads. New/default-history threads can reject history and resume; the adapter now preserves metadata/configuration access, reports details unavailable and retries the richer capability. No live model turn was invoked during this check. Tool/file-edit lifecycle and settings submission are verified with explicit JSON-RPC and browser fixtures, not claimed as live-model validation.

Codex thread settings are not per-turn execution telemetry: confirmed active model/effort therefore say **Not reported**. Clearing a role override keeps the backend’s current configuration; it does not reset sticky settings. Shell/MCP file changes without a structured file-change item are not attributed. Activity retention is bounded and in-memory for the daemon lifetime; daemon restart archival and cross-browser run history are outside this change.

Approval detection, orange state, request links and approval counts belong to the complementary, independent approval PR #246 (https://github.com/omar-os/omar/pull/246). Its optional `/v1/approvals` snapshot/event source remains independent of this activity source. This branch starts directly at upstream main `302d314` and includes neither #244 nor #245. Integration notes and the exact support matrix are in `docs/agent-activity.md`.

## Validation

- Rust: 403 tests pass, including real concurrent invocation-registry completion and bounded-history replay regression.
- Clippy `--all-targets -- -D warnings`, formatting and generated protocol check pass.
- Web: lint, 16 unit/protocol tests, hosted build and embedded SPA build pass.
- Playwright: 49 tests pass; new explicit fixtures cover concurrent agents, long tool, inactivity configuration, diffs, next-invocation settings, disconnect/reconnect, reload, completion, and desktop/mobile rendering.
- Real daemon conformance: 13 tests pass, including stub-agent invocation timing and retained completion after diagram shutdown.
- The two existing `tsc --noEmit` errors in `worker/index.ts` (`Fetcher`, `D1Database`) remain unchanged.

The user’s live Omar instance and agents were not used or modified. Fork CI may require maintainer approval before it runs.
