### PR TITLE
Let a string port name the values it accepts

### DIFF
--- a/lang/Omar/Compiler.lean
+++ b/lang/Omar/Compiler.lean
@@ -254,10 +254,27 @@ private def natural : Parser Nat
   | Token.nat value :: rest => pure (value, rest)
   | tokens => throw s!"expected natural number, found {reprStr tokens.head?}"
 
+/-- The quoted values of a `string in [...]` refinement, up to the closing
+    bracket. Empty is rejected here: a port no value satisfies is a mistake,
+    and saying so at compile time beats failing every write at run time. -/
+private partial def parseRefinement : Parser (Array String)
+  | Token.text value :: Token.sym "," :: rest => do
+      let (tail, rest) ← parseRefinement rest
+      pure (#[value] ++ tail, rest)
+  | Token.text value :: Token.sym "]" :: rest => pure (#[value], rest)
+  | tokens => throw s!"expected a quoted value in a string refinement, found {reprStr tokens.head?}"
+
 private partial def parseType : Parser String
   | Token.word "bool" :: rest => pure ("bool", rest)
   | Token.word "int" :: rest => pure ("int", rest)
   | Token.word "float" :: rest => pure ("float", rest)
+  -- A refinement rides inside the type string rather than in a field of its
+  -- own, so the bytecode format is unchanged and connection checking stays
+  -- equality over this one canonical spelling.
+  | Token.word "string" :: Token.word "in" :: rest => do
+      let (_, rest) ← expectSym "[" rest
+      let (values, rest) ← parseRefinement rest
+      pure (s!"string in {(Json.arr (values.map toJson)).compress}", rest)
   | Token.word "string" :: rest => pure ("string", rest)
   | Token.word "path" :: rest => pure ("path", rest)
   | Token.word "bytes" :: rest => pure ("bytes", rest)

--- a/lang/Omar/Compiler.lean
+++ b/lang/Omar/Compiler.lean
@@ -262,6 +262,7 @@ private partial def parseRefinement : Parser (Array String)
       let (tail, rest) ← parseRefinement rest
       pure (#[value] ++ tail, rest)
   | Token.text value :: Token.sym "]" :: rest => pure (#[value], rest)
+  | Token.sym "]" :: _ => throw "a string refinement must list at least one value"
   | tokens => throw s!"expected a quoted value in a string refinement, found {reprStr tokens.head?}"
 
 private partial def parseType : Parser String

--- a/src/stub_agent.rs
+++ b/src/stub_agent.rs
@@ -97,6 +97,11 @@ fn answer(topology: &TopologyMcpContext, fields: &BTreeMap<String, String>) -> R
 
 /// The simplest value the runtime's validator accepts for a declared type.
 fn stub_value(ty: &str) -> Value {
+    // A refined string admits only what it lists, so "stub" is not among the
+    // answers the validator would take. The first one always is.
+    if let Some(allowed) = crate::topology::string_enum(ty) {
+        return allowed.first().map(|o| json!(o)).unwrap_or(Value::Null);
+    }
     if let Some(inner) = ty.strip_prefix("list<").and_then(|t| t.strip_suffix('>')) {
         return json!([stub_value(inner)]);
     }
@@ -157,5 +162,17 @@ mod tests {
         let list = stub_value("list<int>");
         assert_eq!(list.as_array().map(|items| items.len()), Some(1));
         assert_eq!(list[0].as_i64(), Some(0));
+    }
+
+    #[test]
+    fn a_refined_string_stubs_to_a_value_it_admits() {
+        // "stub" is not one of these, so without the refinement branch every
+        // program declaring one would fail its first write.
+        assert_eq!(
+            stub_value("string in [\"continue\",\"stop\"]"),
+            json!("continue")
+        );
+        let list = stub_value("list<string in [\"a\",\"b\"]>");
+        assert_eq!(list, json!(["a"]));
     }
 }

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -1094,8 +1094,16 @@ fn validate_value(ty: &str, value: &Value) -> Result<()> {
         let text = value
             .as_str()
             .with_context(|| format!("expected {ty}, got {value}"))?;
+        // `omarc` rejects an empty refinement, so this is reachable only from
+        // hand-written bytecode. Say what is wrong with the port rather than
+        // offering the agent a choice of nothing.
+        if allowed.is_empty() {
+            bail!("port type {ty} admits no value");
+        }
         if !allowed.iter().any(|option| option == text) {
-            let options: Vec<String> = allowed.iter().map(|o| format!("\"{o}\"")).collect();
+            // Quoted by serde rather than by hand: an admitted value may itself
+            // contain a quote or a newline, and the agent reads this message.
+            let options: Vec<String> = allowed.iter().map(|o| json!(o).to_string()).collect();
             bail!("expected one of {}, got {value}", options.join(", "));
         }
         return Ok(());
@@ -2663,6 +2671,24 @@ mod tests {
         assert!(validate_value(ty, &json!(1)).is_err());
         validate_value("list<string in [\"a\",\"b\"]>", &json!(["a", "b"])).unwrap();
         assert!(validate_value("list<string in [\"a\",\"b\"]>", &json!(["c"])).is_err());
+    }
+
+    #[test]
+    fn a_refinement_reports_awkward_values_readably() {
+        // An admitted value may contain a quote or a newline, and the agent
+        // reads the rejection, so the options are quoted by serde.
+        let ty = r#"string in ["say \"hi\"","two\nlines"]"#;
+        validate_value(ty, &json!("say \"hi\"")).unwrap();
+        let rejected = validate_value(ty, &json!("no")).unwrap_err().to_string();
+        assert!(rejected.contains(r#""say \"hi\"""#), "{rejected}");
+        assert!(rejected.contains(r#""two\nlines""#), "{rejected}");
+
+        // `omarc` rejects an empty refinement; hand-written bytecode can still
+        // carry one, and it is the port that is wrong, not the value.
+        let empty = validate_value("string in []", &json!("anything"))
+            .unwrap_err()
+            .to_string();
+        assert!(empty.contains("admits no value"), "{empty}");
     }
 
     #[test]

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -374,18 +374,7 @@ pub fn verify(bytecode: &Bytecode) -> Result<VmState> {
                 if ty.trim().is_empty() {
                     bail!("port '{name}' has an empty type");
                 }
-                // A refinement that does not parse is a broken port, not a
-                // plain `string`. Saying so here, once, keeps `string_enum`
-                // free to answer "not refined" everywhere downstream.
-                if let Some(list) = ty.strip_prefix("string in ") {
-                    match serde_json::from_str::<Vec<String>>(list) {
-                        Ok(values) if !values.is_empty() => {}
-                        Ok(_) => bail!("port '{name}' admits no value"),
-                        Err(error) => {
-                            bail!("port '{name}' has an invalid string refinement: {error}")
-                        }
-                    }
-                }
+                check_refinement(name, ty)?;
                 if delay.is_some() && *kind != PortKind::Action {
                     bail!("only action ports may declare a fixed delay");
                 }
@@ -1150,6 +1139,29 @@ fn validate_value(ty: &str, value: &Value) -> Result<()> {
         bail!("expected {ty}, got {value}");
     }
     Ok(())
+}
+
+/// Reject a refinement that does not parse, wherever it sits in the type.
+///
+/// A refinement that is not well formed is a broken port, not a plain `string`.
+/// Saying so once, here, keeps `string_enum` free to answer "not refined"
+/// everywhere downstream. `validate_value` looks inside `list` and `option`, so
+/// this has to as well, or a nested one would reach the agent and be reported
+/// against the value it wrote rather than against the port.
+fn check_refinement(name: &str, ty: &str) -> Result<()> {
+    for outer in ["list", "option"] {
+        if let Some(inner) = generic_inner(ty, outer) {
+            return check_refinement(name, inner);
+        }
+    }
+    let Some(list) = ty.strip_prefix("string in ") else {
+        return Ok(());
+    };
+    match serde_json::from_str::<Vec<String>>(list) {
+        Ok(values) if !values.is_empty() => Ok(()),
+        Ok(_) => bail!("port '{name}' admits no value"),
+        Err(error) => bail!("port '{name}' has an invalid string refinement: {error}"),
+    }
 }
 
 fn generic_inner<'a>(ty: &'a str, outer: &str) -> Option<&'a str> {
@@ -2667,6 +2679,13 @@ mod tests {
             (r#"string in [oops"#, "invalid string refinement"),
             (r#"string in [1,2]"#, "invalid string refinement"),
             (r#"string in []"#, "admits no value"),
+            // `validate_value` looks inside these, so `verify` must too.
+            (r#"list<string in [oops>"#, "invalid string refinement"),
+            (r#"option<string in []>"#, "admits no value"),
+            (
+                r#"list<option<string in [1,2]>>"#,
+                "invalid string refinement",
+            ),
         ] {
             let mut program = program();
             program.instructions[2] = serde_json::from_str(&format!(

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -1077,7 +1077,29 @@ fn validate_invocation_owner(team: &str, agent: &str, invocation: &InvocationRec
     Ok(())
 }
 
+/// The values a refined string type admits, or `None` if `ty` is not one.
+///
+/// A refinement travels inside the flat type string -- `string in ["a","b"]` --
+/// rather than in a field of its own. Nothing downstream has to learn a new
+/// shape: the bytecode's `type` stays a string, and connection checking stays
+/// equality over the canonical spelling `omarc` emits.
+pub(crate) fn string_enum(ty: &str) -> Option<Vec<String>> {
+    serde_json::from_str(ty.strip_prefix("string in ")?).ok()
+}
+
 fn validate_value(ty: &str, value: &Value) -> Result<()> {
+    if let Some(allowed) = string_enum(ty) {
+        // The agent acts on this message, so it names every legal answer
+        // rather than only reporting that this one was wrong.
+        let text = value
+            .as_str()
+            .with_context(|| format!("expected {ty}, got {value}"))?;
+        if !allowed.iter().any(|option| option == text) {
+            let options: Vec<String> = allowed.iter().map(|o| format!("\"{o}\"")).collect();
+            bail!("expected one of {}, got {value}", options.join(", "));
+        }
+        return Ok(());
+    }
     if let Some(inner) = generic_inner(ty, "list") {
         let values = value
             .as_array()
@@ -1755,6 +1777,12 @@ pub fn parse_inputs(state: &VmState, raw_inputs: &[String]) -> Result<BTreeMap<S
 }
 
 fn parse_input_value(ty: &str, value: &str) -> Result<Value> {
+    // A refined string is still supplied as bare text on the command line;
+    // whether it is one of the values the port admits is `validate_value`'s
+    // answer, not the parser's.
+    if string_enum(ty).is_some() {
+        return Ok(Value::String(value.to_string()));
+    }
     match ty {
         "bool" => Ok(Value::Bool(value.parse()?)),
         "int" => Ok(json!(value.parse::<i64>()?)),
@@ -2616,6 +2644,25 @@ mod tests {
         let mut program = program();
         program.instructions.pop();
         assert!(verify(&program).is_err());
+    }
+
+    #[test]
+    fn a_refined_string_admits_only_what_it_lists() {
+        let ty = "string in [\"continue\",\"stop\"]";
+        validate_value(ty, &json!("continue")).unwrap();
+        validate_value(ty, &json!("stop")).unwrap();
+
+        // The failure the refinement exists for: a value that is a perfectly
+        // good string and not one of the answers the port accepts.
+        let rejected = validate_value(ty, &json!("this is a terminal record, not a forward"))
+            .unwrap_err()
+            .to_string();
+        assert!(rejected.contains("\"continue\""), "{rejected}");
+        assert!(rejected.contains("\"stop\""), "{rejected}");
+
+        assert!(validate_value(ty, &json!(1)).is_err());
+        validate_value("list<string in [\"a\",\"b\"]>", &json!(["a", "b"])).unwrap();
+        assert!(validate_value("list<string in [\"a\",\"b\"]>", &json!(["c"])).is_err());
     }
 
     #[test]

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -374,6 +374,18 @@ pub fn verify(bytecode: &Bytecode) -> Result<VmState> {
                 if ty.trim().is_empty() {
                     bail!("port '{name}' has an empty type");
                 }
+                // A refinement that does not parse is a broken port, not a
+                // plain `string`. Saying so here, once, keeps `string_enum`
+                // free to answer "not refined" everywhere downstream.
+                if let Some(list) = ty.strip_prefix("string in ") {
+                    match serde_json::from_str::<Vec<String>>(list) {
+                        Ok(values) if !values.is_empty() => {}
+                        Ok(_) => bail!("port '{name}' admits no value"),
+                        Err(error) => {
+                            bail!("port '{name}' has an invalid string refinement: {error}")
+                        }
+                    }
+                }
                 if delay.is_some() && *kind != PortKind::Action {
                     bail!("only action ports may declare a fixed delay");
                 }
@@ -2645,6 +2657,26 @@ mod tests {
         assert_eq!(state.agents.len(), 1);
         assert_eq!(state.ports.len(), 2);
         assert_eq!(state.reactions.len(), 1);
+    }
+
+    #[test]
+    fn rejects_a_port_whose_refinement_does_not_parse() {
+        // `omarc` cannot emit either of these. Hand-written bytecode can, and
+        // the port is what is wrong -- not the first value written to it.
+        for (ty, expected) in [
+            (r#"string in [oops"#, "invalid string refinement"),
+            (r#"string in [1,2]"#, "invalid string refinement"),
+            (r#"string in []"#, "admits no value"),
+        ] {
+            let mut program = program();
+            program.instructions[2] = serde_json::from_str(&format!(
+                r#"{{"op":"define_port","kind":"input","name":"request","type":{}}}"#,
+                serde_json::to_string(ty).unwrap()
+            ))
+            .unwrap();
+            let error = verify(&program).unwrap_err().to_string();
+            assert!(error.contains(expected), "{ty} gave {error}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
Partially addresses #230.

A `string` port admits any text, so an agent can satisfy an effect contract
with a value that means the opposite of what the port is for. The ring
benchmark's node answered its forward port with:

> this value exists only because the runtime enforces the r10.fwd2 effect
> contract; it is a terminal record, not a forward.

Presence and type were both checked. Nothing looked at the value.

## What this adds

```omar
output out : string in ["continue", "stop"]
